### PR TITLE
Correct syntax

### DIFF
--- a/src/plugin/media_metadata/ffprobe/src/ffprobe_lib.cpp
+++ b/src/plugin/media_metadata/ffprobe/src/ffprobe_lib.cpp
@@ -102,7 +102,7 @@ AVDictionary **init_find_stream_opts(AVFormatContext *avfc, AVDictionary *codec_
     AVDictionary **result = nullptr;
 
     if (avfc->nb_streams) {
-        result = (AVDictionary **)av_mallocz_array(avfc->nb_streams, sizeof(*result));
+        result = (AVDictionary **)av_malloc_array(avfc->nb_streams, sizeof(*result));
 
         if (result) {
             for (unsigned int i = 0; i < avfc->nb_streams; i++)


### PR DESCRIPTION
Delete the "z" in av_malloc_array, this gave me an error when building in Arch Linux

```
/home/adro/Applications/AUR/xstudio/src/xstudio/src/plugin/media_metadata/ffprobe/src/ffprobe_lib.cpp:105:35: error: ‘av_mallocz_array’ was not declared in this scope; did you mean ‘av_malloc_array’?
  105 |         result = (AVDictionary **)av_mallocz_array(avfc->nb_streams, sizeof(*result));
      |                                   ^~~~~~~~~~~~~~~~
      |                                   av_malloc_array
```