### PR TITLE
Allow setting CAF_ROOT_DIR

### DIFF
--- a/cmake/modules/FindCAF.cmake
+++ b/cmake/modules/FindCAF.cmake
@@ -18,8 +18,6 @@
 #  CAF_LIBRARY_$C         Library file for component $C
 #  CAF_INCLUDE_DIR_$C     Include path for component $C
 
-set(CAF_ROOT_DIR "/user_data/.tmp/caf")
-
 if(CAF_FIND_COMPONENTS STREQUAL "")
   message(FATAL_ERROR "FindCAF requires at least one COMPONENT.")
 endif()


### PR DESCRIPTION
Using the  `CAF_ROOT_DIR` definition to tell cmake the location of the actor framework library currently doesn't work.
Removing this bit of what looks like testing code fixes the issue.