### PR TITLE
Add missing cmake dependences 

### DIFF
--- a/src/plugin/colour_pipeline/ocio/src/CMakeLists.txt
+++ b/src/plugin/colour_pipeline/ocio/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(OpenColorIO CONFIG)
 find_package(OpenEXR)
 find_package(Imath)
+find_package(GLEW REQUIRED)
 
 # Temporary hack - OCIO package is not found/defined by 'modern' .cmake
 # package and as such cmake doesn't distinguish the OCIO headers as system
@@ -11,6 +12,7 @@ include_directories(SYSTEM ${OCIO_INCLUDE_DIRS})
 SET(LINK_DEPS
 	xstudio::colour_pipeline
 	xstudio::module
+	GLEW::GLEW
 	OpenColorIO::OpenColorIO
 	OpenEXR::OpenEXR
 	Imath::Imath

--- a/src/plugin/media_reader/blank/src/CMakeLists.txt
+++ b/src/plugin/media_reader/blank/src/CMakeLists.txt
@@ -1,5 +1,8 @@
+find_package(GLEW REQUIRED)
+
 SET(LINK_DEPS
 	xstudio::media_reader
+	GLEW::GLEW
 )
 
 create_plugin_with_alias(media_reader_blank xstudio::media_reader::blank 0.1.0  "${LINK_DEPS}")

--- a/src/plugin/media_reader/ffmpeg/src/CMakeLists.txt
+++ b/src/plugin/media_reader/ffmpeg/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(media_reader_ffmpeg VERSION 0.1.0 LANGUAGES CXX)
 
 find_package(FFMPEG REQUIRED COMPONENTS avcodec avformat swscale avutil)
-
+find_package(GLEW REQUIRED)
 
 set(SOURCES
 	ffmpeg_stream.cpp
@@ -22,6 +22,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE -Wfatal-errors)
 target_link_libraries(${PROJECT_NAME}
 	PUBLIC
 		xstudio::media_reader
+		GLEW::GLEW
 		FFMPEG::avcodec
 		FFMPEG::avformat
 		FFMPEG::swscale

--- a/src/plugin/media_reader/openexr/src/CMakeLists.txt
+++ b/src/plugin/media_reader/openexr/src/CMakeLists.txt
@@ -1,8 +1,10 @@
 find_package(OpenEXR)
 find_package(Imath)
+find_package(GLEW)
 
 SET(LINK_DEPS
 	xstudio::media_reader
+	GLEW::GLEW
 	OpenEXR::OpenEXR
 	Imath::Imath
 )

--- a/src/plugin/media_reader/ppm/src/CMakeLists.txt
+++ b/src/plugin/media_reader/ppm/src/CMakeLists.txt
@@ -1,5 +1,8 @@
+find_package(GLEW REQUIRED)
+
 SET(LINK_DEPS
 	xstudio::media_reader
+	GLEW::GLEW
 )
 
 create_plugin_with_alias(media_reader_ppm xstudio::media_reader::ppm 0.1.0  "${LINK_DEPS}")

--- a/src/utility/src/CMakeLists.txt
+++ b/src/utility/src/CMakeLists.txt
@@ -1,6 +1,14 @@
+find_package(spdlog REQUIRED)
+find_package(fmt REQUIRED)
+find_package(Imath REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_search_module(UUID REQUIRED uuid)
+
 SET(LINK_DEPS
 	caf::core
 	fmt::fmt
+	Imath::Imath	
 	nlohmann_json::nlohmann_json
 	reproc++
 	spdlog::spdlog
@@ -11,6 +19,7 @@ SET(LINK_DEPS
 SET(STATIC_LINK_DEPS
 	caf::core
 	fmt::fmt
+	Imath::Imath
 	nlohmann_json::nlohmann_json
 	reproc++
 	spdlog::spdlog
@@ -18,10 +27,5 @@ SET(STATIC_LINK_DEPS
 	uuid
 )
 
-find_package(spdlog REQUIRED)
-find_package(fmt REQUIRED)
-find_package(nlohmann_json REQUIRED)
-find_package(PkgConfig REQUIRED)
-pkg_search_module(UUID REQUIRED uuid)
 
 create_component_static(utility 0.1.0 "${LINK_DEPS}" "${STATIC_LINK_DEPS}")


### PR DESCRIPTION
While getting xstudio to build in a rez environment I discovered that these targets were missing dependencies.
I believe the compiler just needs header-only things from these packages and that is why the linker has never caused any errors. 
If you installed all your dependencies are install under the same prefix the compiler is able to find them. This isn't always the case in an environment like rez were each package has their own prefix.