### PR TITLE
Add missing close button decorator to tool windows (missing on Windows builds). Fixes #109.

### DIFF
--- a/ui/qml/xstudio/base/dialogs/XsWindow.qml
+++ b/ui/qml/xstudio/base/dialogs/XsWindow.qml
@@ -66,6 +66,6 @@ ApplicationWindow {
         }
     }
 
-    flags: (asDialog ? Qt.Dialog : asWindow ? Qt.WindowSystemMenuHint : Qt.SubWindow) |(frameLess ? Qt.FramelessWindowHint : 0) | (onTop ? Qt.WindowStaysOnTopHint : 0)
+    flags: (asDialog ? Qt.Dialog : asWindow ? Qt.WindowSystemMenuHint : Qt.Tool | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowSystemMenuHint) | (frameLess ? Qt.FramelessWindowHint : 0) | (onTop ? Qt.WindowStaysOnTopHint : 0)
     color: "#222"
 }


### PR DESCRIPTION
Adds a close button to tool panels e.g. Python Console, Notes etc, which is otherwise missing in a Windows build.