### PR TITLE
146: Resolve dylib rpath issues in MacOS app bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ python/src/xstudio/version.py
 .vs/
 .DS_Store
 /build/
+xstudio_install/
+**/qml/*_qml_export.h

--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -101,10 +101,12 @@ macro(default_options_local name)
 	    	$<BUILD_INTERFACE:${ROOT_DIR}/extern/include>
 	)
 	if (APPLE)
-		set_target_properties(${name}
-	    	PROPERTIES
-	    	LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/xSTUDIO.app/Contents/Frameworks"
-		)
+    set_target_properties(${name}
+        PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/xSTUDIO.app/Contents/Frameworks"
+        INSTALL_RPATH "@executable_path/../Frameworks"
+        INSTALL_RPATH_USE_LINK_PATH TRUE
+    )
 	else()
 		set_target_properties(${name}
 	    	PROPERTIES
@@ -204,7 +206,7 @@ macro(default_plugin_options name)
 				COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${PROJECT_NAME}>" "${CMAKE_CURRENT_BINARY_DIR}/plugin"
 		)
 	endif()
-	
+
 endmacro()
 
 macro(add_plugin_qml name _dir)
@@ -366,7 +368,7 @@ macro(add_python_plugin NAME)
             copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/${NAME} ${CMAKE_BINARY_DIR}/bin/plugin-python/${NAME})
 
 	endif()
-	
+
 endmacro()
 
 macro(create_plugin NAME VERSION DEPS)

--- a/src/global/src/CMakeLists.txt
+++ b/src/global/src/CMakeLists.txt
@@ -57,4 +57,12 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(${PROJECT_NAME} PRIVATE asound)  # Link against asound on Linux
 endif()
 
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_DEPENDS_NO_SHARED true)
+if(APPLE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        LINK_DEPENDS_NO_SHARED true
+        INSTALL_RPATH "@executable_path/../Frameworks"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+else()
+    set_target_properties(${PROJECT_NAME} PROPERTIES LINK_DEPENDS_NO_SHARED true)
+endif()

--- a/src/launch/xstudio/src/CMakeLists.txt
+++ b/src/launch/xstudio/src/CMakeLists.txt
@@ -12,12 +12,12 @@ set(SOURCES
 	xstudio.cpp
 	xstudio_win_resource.rc
 	../../../../ui/qml/xstudio/qml.qrc
-	)	
+	)
 else()
 set(SOURCES
 	xstudio.cpp
 	../../../../ui/qml/xstudio/qml.qrc
-	)	
+	)
 endif()
 if(WIN32)
     # Add the /bigobj option for xstudio.cpp
@@ -133,6 +133,12 @@ elseif(APPLE)
     find_program(macdeployqt_exe macdeployqt HINTS "${_qt_bin_dir}")
         configure_file(macdeploy.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/macdeploy.cmake @ONLY)
     install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/macdeploy.cmake)
+
+    # Add custom command to fix library paths after build
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -DAPP_BUNDLE_DIR=${CMAKE_BINARY_DIR}/xSTUDIO.app
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/fixup_macos_bundle.cmake
+    )
 
 else()
 

--- a/src/launch/xstudio/src/fixup_macos_bundle.cmake
+++ b/src/launch/xstudio/src/fixup_macos_bundle.cmake
@@ -1,0 +1,15 @@
+# Fix library paths in the app bundle to ensure they're relative
+file(GLOB_RECURSE LIBRARIES "${APP_BUNDLE_DIR}/Contents/Frameworks/*.dylib")
+foreach(LIB ${LIBRARIES})
+    get_filename_component(LIB_NAME ${LIB} NAME)
+    execute_process(COMMAND install_name_tool -id "@rpath/${LIB_NAME}" ${LIB})
+endforeach()
+
+# Fix executable references to libraries
+execute_process(
+    COMMAND
+    install_name_tool
+    -add_rpath
+    "@executable_path/../Frameworks"
+    ${APP_BUNDLE_DIR}/Contents/MacOS/xstudio.bin
+)

--- a/src/launch/xstudio/src/macdeploy.cmake.in
+++ b/src/launch/xstudio/src/macdeploy.cmake.in
@@ -1,3 +1,19 @@
 message("Running @macdeployqt_exe@ with args: ${CMAKE_BINARY_DIR}/xSTUDIO.app -qmldir=@CMAKE_SOURCE_DIR@/ui")
 execute_process(COMMAND "@macdeployqt_exe@" ${CMAKE_BINARY_DIR}/xSTUDIO.app -qmldir=@CMAKE_SOURCE_DIR@/ui
     WORKING_DIRECTORY "${CMAKE_INSTALL_PREFIX}")
+
+# Fix library paths to ensure they're relative to the bundle
+execute_process(
+    COMMAND
+    install_name_tool -id
+    "@rpath/libglobal.dylib"
+    ${CMAKE_BINARY_DIR}/xSTUDIO.app/Contents/Frameworks/libglobal.dylib
+)
+execute_process(
+    COMMAND
+    install_name_tool
+    -change
+    "@rpath/libglobal.dylib"
+    "@executable_path/../Frameworks/libglobal.dylib"
+    ${CMAKE_BINARY_DIR}/xSTUDIO.app/Contents/MacOS/xstudio.bin
+)


### PR DESCRIPTION
### Linked issues

Fixes #146 

### Summarize your change.

Configure proper rpath settings for macOS app bundles to ensure dynamic libraries are correctly located at runtime. This includes setting `INSTALL_RPATH` and using `install_name_tool` to fix library paths in both the app bundle and executable.

Added a new cmake script to automatically fix library paths after build and updated `macdeployqt` integration to handle rpath changes for `libglobal.dylib`.

I also modified `.gitignore` to include side-products of the build process located outside of the build directory.

### Describe the reason for the change.

The app bundle is not portable, i.e. not directly usable on another machine.

### Describe what you have tested and on which operating system.

Tested on MacOS 15.6.1 as follows:

1. Machine A: compile `xStudio.app`
2. Machine A: check `xStudio.app` is working correctly.
3. Copy machine A's `xStudio.app` to machine B.
4. machine B: `xStudio.app` is working correctly.
