### PR TITLE
148: fix timeline zoom behavior on MacOS laptops

### DIFF
--- a/ui/qml/xstudio/views/timeline/XsTimeline.qml
+++ b/ui/qml/xstudio/views/timeline/XsTimeline.qml
@@ -1508,10 +1508,16 @@ Rectangle {
             onWheel: {
                 // maintain position as we zoom..
                 if(wheel.modifiers == Qt.ShiftModifier) {
-                    if(wheel.angleDelta.y > 1) {
-                        scaleY += 0.2
+                    // wheel.angleDelta.y always return 0 on MacOS laptops
+                    // when SHIFT is pressed and a mouse wheel is used, but in
+                    // that case the x component is updating and usable.
+                    let deltaY = wheel.angleDelta.y == 0 ? wheel.angleDelta.x : wheel.angleDelta.y
+                    // Limit the scale to keep it within a usable range and
+                    // avoid a negative scaleY value.
+                    if(deltaY > 1) {
+                        scaleY = Math.min(2.0, scaleY + 0.2)
                     } else {
-                        scaleY -= 0.2
+                        scaleY = Math.max(0.6, scaleY - 0.2)
                     }
                     wheel.accepted = true
                 } else if(wheel.modifiers == Qt.ControlModifier) {


### PR DESCRIPTION
### Linked issues

Fixes #148 

### Summarize your change.

- When using a mouse on MacOS laptops with trackpads, `wheel.angleDelta.y` always returns `0` when SHIFT is pressed, but the x component changes instead. Use x if y is 0 to enable zooming.
- Note that the scrolling trackpad gesture changes the y value as expected. This change handles both cases.
- Also limit scaleY between `0.6` and `2.0` to prevent unusable values.

### Describe the reason for the change.

When shift-wheel scrolling over the timeline. the items shrink until they disappear. Once vertical scale has become negative, studio will hang.
The only way to recover is to quit studio, open `~/.config/DNEG/xstudio/preferences/qml_ui.json` and reset the `verticalScale` pref to 1.

### Describe what you have tested and on which operating system.

- OS: MacOS 15.6.1
- M4 MacBookPro with a Logitech MxAnywhere 3s Mouse

I tested with and without mouse (using the trackpad).

### Add a list of changes, and note any that might need special attention during the review.

This is a non-breaking change.

### If possible, provide screenshots.

BAD: The items have shrunk and became invisible.
<img width="1237" height="340" alt="image" src="https://github.com/user-attachments/assets/2c840326-bae1-4283-9337-6887cf0fa3de" />

Minimum vertical size: 0.6
<img width="1235" height="255" alt="image" src="https://github.com/user-attachments/assets/acd11e6a-37ec-48fa-bfde-b50ee975a875" />

Maximum vertical size: 2.0
<img width="1236" height="257" alt="image" src="https://github.com/user-attachments/assets/349656ac-a8bb-4cc4-9e09-e861d1cde57e" />
