### PR TITLE
Feature to allow for optionally disabling ssl verification.

### DIFF
--- a/include/xstudio/http_client/http_client_actor.hpp
+++ b/include/xstudio/http_client/http_client_actor.hpp
@@ -15,7 +15,8 @@ namespace http_client {
             caf::actor_config &cfg,
             time_t connection_timeout = CPPHTTPLIB_CONNECTION_TIMEOUT_SECOND,
             time_t read_timeout       = CPPHTTPLIB_READ_TIMEOUT_SECOND,
-            time_t write_timeout      = CPPHTTPLIB_WRITE_TIMEOUT_SECOND);
+            time_t write_timeout      = CPPHTTPLIB_WRITE_TIMEOUT_SECOND,
+            bool ssl_verify           = true);
         ~HTTPClientActor() override = default;
 
         const char *name() const override { return NAME.c_str(); }
@@ -30,6 +31,7 @@ namespace http_client {
         time_t connection_timeout_;
         time_t read_timeout_;
         time_t write_timeout_;
+        bool ssl_verify_;
     };
 
     class HTTPWorker : public caf::event_based_actor {
@@ -38,7 +40,8 @@ namespace http_client {
             caf::actor_config &cfg,
             time_t connection_timeout = CPPHTTPLIB_CONNECTION_TIMEOUT_SECOND,
             time_t read_timeout       = CPPHTTPLIB_READ_TIMEOUT_SECOND,
-            time_t write_timeout      = CPPHTTPLIB_WRITE_TIMEOUT_SECOND);
+            time_t write_timeout      = CPPHTTPLIB_WRITE_TIMEOUT_SECOND,
+            bool ssl_verify           = true);
         ~HTTPWorker() override = default;
 
         const char *name() const override { return NAME.c_str(); }

--- a/src/http_client/src/http_client_actor.cpp
+++ b/src/http_client/src/http_client_actor.cpp
@@ -64,7 +64,8 @@ HTTPWorker::HTTPWorker(
     caf::actor_config &cfg,
     time_t connection_timeout,
     time_t read_timeout,
-    time_t write_timeout)
+    time_t write_timeout,
+    bool ssl_verify)
     : caf::event_based_actor(cfg) {
     behavior_.assign(
         [=](xstudio::broadcast::broadcast_down_atom, const caf::actor_addr &) {},
@@ -81,6 +82,8 @@ HTTPWorker::HTTPWorker(
                 cli.set_connection_timeout(connection_timeout, 0);
                 cli.set_read_timeout(read_timeout, 0);
                 cli.set_write_timeout(write_timeout, 0);
+                cli.enable_server_certificate_verification(ssl_verify);
+
                 auto res = [&]() -> httplib::Result {
                     if (content_type.empty())
                         return cli.Delete(path.c_str(), headers);
@@ -135,6 +138,7 @@ HTTPWorker::HTTPWorker(
                 cli.set_connection_timeout(connection_timeout, 0);
                 cli.set_read_timeout(read_timeout, 0);
                 cli.set_write_timeout(write_timeout, 0);
+                cli.enable_server_certificate_verification(ssl_verify);
 
                 // cli.set_logger([](const auto& req, const auto& res) {
                 //     spdlog::warn("{}", req.);
@@ -200,6 +204,8 @@ HTTPWorker::HTTPWorker(
                 cli.set_connection_timeout(connection_timeout, 0);
                 cli.set_read_timeout(read_timeout, 0);
                 cli.set_write_timeout(write_timeout, 0);
+                cli.enable_server_certificate_verification(ssl_verify);
+
                 auto res = [&]() -> httplib::Result {
                     if (content_type.empty())
                         return cli.Post(path.c_str(), headers, params);
@@ -257,6 +263,7 @@ HTTPWorker::HTTPWorker(
                 cli.set_connection_timeout(connection_timeout, 0);
                 cli.set_read_timeout(read_timeout, 0);
                 cli.set_write_timeout(write_timeout, 0);
+                cli.enable_server_certificate_verification(ssl_verify);
 
                 auto res = [&]() -> httplib::Result {
                     if (content_type.empty())
@@ -311,11 +318,13 @@ HTTPClientActor::HTTPClientActor(
     caf::actor_config &cfg,
     time_t connection_timeout,
     time_t read_timeout,
-    time_t write_timeout)
+    time_t write_timeout,
+    bool ssl_verify)
     : caf::event_based_actor(cfg),
       connection_timeout_(connection_timeout),
       read_timeout_(read_timeout),
-      write_timeout_(write_timeout) {
+      write_timeout_(write_timeout),
+      ssl_verify_(ssl_verify) {
     init();
 }
 
@@ -339,7 +348,7 @@ void HTTPClientActor::init() {
         worker_count,
         [&] {
             return system().spawn<HTTPWorker>(
-                connection_timeout_, read_timeout_, write_timeout_);
+                connection_timeout_, read_timeout_, write_timeout_, ssl_verify_);
         },
         caf::actor_pool::round_robin());
 


### PR DESCRIPTION
This modifies the HTTPClientActor class to allow for optionally disabling SSL verification. Default behaviour should remain unchanged, with SSL verification enabled.

Tested under MacOS.