### PR TITLE
OCIO view hotkeys, working_space, and file-path remapping

### DIFF
--- a/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
@@ -394,11 +394,13 @@ OCIOEngine::get_ocio_config(const utility::JsonStore &src_colour_mgmt_metadata) 
     return config;
 }
 
-const char *
+std::string
 OCIOEngine::working_space(const utility::JsonStore &src_colour_mgmt_metadata) const {
     auto config = get_ocio_config(src_colour_mgmt_metadata);
     if (not config) {
         return "";
+    } else if (src_colour_mgmt_metadata.contains("working_space")) {
+        return src_colour_mgmt_metadata["working_space"].get<std::string>();
     } else if (config->hasRole(OCIO::ROLE_SCENE_LINEAR)) {
         return OCIO::ROLE_SCENE_LINEAR;
     } else {
@@ -555,7 +557,7 @@ OCIO::TransformRcPtr OCIOEngine::display_transform(
         }
 
         OCIO::DisplayViewTransformRcPtr dt = OCIO::DisplayViewTransform::Create();
-        dt->setSrc(working_space(src_colour_mgmt_metadata));
+        dt->setSrc(working_space(src_colour_mgmt_metadata).c_str());
         dt->setDisplay(_display.c_str());
         dt->setView(_view.c_str());
         dt->setDirection(OCIO::TRANSFORM_DIR_FORWARD);

--- a/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "ocio_engine.hpp"
 
+#include "xstudio/utility/helpers.hpp"
 #include "xstudio/utility/string_helpers.hpp"
 #include "xstudio/ui/opengl/shader_program_base.hpp"
 #include "xstudio/thumbnail/thumbnail.hpp"
@@ -328,7 +329,8 @@ OCIO::ConstConfigRcPtr
 OCIOEngine::get_ocio_config(const utility::JsonStore &src_colour_mgmt_metadata) const {
 
     const std::string config_name =
-        src_colour_mgmt_metadata.get_or("ocio_config", default_config_);
+        utility::forward_remap_file_path(
+            src_colour_mgmt_metadata.get_or("ocio_config", default_config_));
     const std::string displays =
         src_colour_mgmt_metadata.get_or("active_displays", std::string(""));
     const std::string views  = src_colour_mgmt_metadata.get_or("active_views", std::string(""));
@@ -378,6 +380,14 @@ OCIOEngine::get_ocio_config(const utility::JsonStore &src_colour_mgmt_metadata) 
         econfig->setActiveDisplays(displays.c_str());
     if (!views.empty())
         econfig->setActiveViews(views.c_str());
+
+    econfig->clearSearchPaths();
+    for (int i = 0; i < config->getNumSearchPaths(); ++i) {
+        auto path = std::string(config->getSearchPath(i));
+        auto newpath = utility::forward_remap_file_path(path);
+        econfig->addSearchPath(newpath.c_str());
+    }
+
     config                     = econfig;
     ocio_config_cache_[concat] = config;
 

--- a/src/plugin/colour_pipeline/ocio/src/ocio_engine.hpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_engine.hpp
@@ -115,7 +115,7 @@ class OCIOEngine {
 
   private:
     // OCIO logic
-    const char *working_space(const utility::JsonStore &src_colour_mgmt_metadata) const;
+    std::string working_space(const utility::JsonStore &src_colour_mgmt_metadata) const;
 
     // OCIO Transform helpers
     OCIO::TransformRcPtr source_transform(

--- a/src/plugin/colour_pipeline/ocio/src/ocio_plugin.cpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_plugin.cpp
@@ -288,6 +288,18 @@ void OCIOColourPipeline::register_hotkeys() {
         channel_hotkeys_[hotkey_id] = hotkey_props.channel_name;
     }
 
+    for (int i = 1; i <= 9; ++i) {
+        auto suffix = std::string(fmt::format(" #{}", i));
+        auto hotkey_id = register_hotkey(
+            int('0')+i,
+            ui::MetaModifier,
+            std::string("Change OCIO View Transform")+suffix,
+            "Changes OCIO view transform",
+            false,
+            "Viewer");
+        view_hotkeys_[hotkey_id] = i;
+    }
+
     reset_hotkey_ = register_hotkey(
         int('R'),
         ui::ControlModifier,
@@ -352,6 +364,18 @@ void OCIOColourPipeline::hotkey_pressed(
     } else if (hotkey_uuid == saturation_hotkey_) {
         saturation_->set_role_data(module::Attribute::Activated, true);
         grab_mouse_focus();
+    } else {
+        auto v = view_hotkeys_.find(hotkey_uuid);
+        if (v != view_hotkeys_.end()) {
+            const auto &views = display_views_[display_->value()];
+            int idx = v->second-1;
+            if (idx >= 0 and idx < views.size()) {
+                const auto &new_view = views[idx];
+                if (new_view != view_->value()) {
+                    view_->set_value(new_view);
+                }
+            }
+        }
     }
 }
 

--- a/src/plugin/colour_pipeline/ocio/src/ocio_plugin.cpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_plugin.cpp
@@ -58,10 +58,10 @@ caf::message_handler OCIOColourPipeline::message_handler_extensions() {
                {
 
                    [=](global_ocio_controls_atom atom,
-                       const std::string &oico_config) -> utility::JsonStore {
+                       const std::string &ocio_config) -> utility::JsonStore {
                        utility::JsonStore res;
 
-                       if (oico_config == current_config_name_) {
+                       if (ocio_config == current_config_name_) {
                            res["source_colour_space"] = source_colour_space_->value();
                            res["display"]             = display_->value();
                            res["view"]                = view_->value();

--- a/src/plugin/colour_pipeline/ocio/src/ocio_plugin.hpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_plugin.hpp
@@ -148,6 +148,7 @@ class OCIOColourPipeline : public ColourPipeline {
     UiText ui_text_;
 
     std::map<utility::Uuid, std::string> channel_hotkeys_;
+    std::map<utility::Uuid, int> view_hotkeys_;
     utility::Uuid exposure_hotkey_;
     utility::Uuid gamma_hotkey_;
     utility::Uuid saturation_hotkey_;

--- a/src/plugin/colour_pipeline/ocio/src/ui_text.hpp
+++ b/src/plugin/colour_pipeline/ocio/src/ui_text.hpp
@@ -55,7 +55,7 @@ struct UiText {
          "Luminance"},
         {int('C'),
          xstudio::ui::NoModifier,
-         "Rever to RGB Mode",
+         "Revert to RGB Mode",
          "Returns to regular RGB colour view mode",
          "RGB"}};
 


### PR DESCRIPTION
Several additions to OCIO colour management.

The first is the addition of Meta+1 through Meta+9 hotkeys for changing the current OCIO view. (Ctrl+1 through Ctrl+9 under MacOS). Note that the commit message mistakenly stated the wrong modifier key. If this conflicts with other's hotkeys I can take it out of this PR or put it behind a preference.

Next, this adds support for utilising xSTUDIO's file-path remapping mechanism to remap OCIO config files specified via metadata and also any search paths within the config.

Finally, this allows the setting of the working_space via the colour management metadata. We find this useful for viewing both colour managed and unmanaged clips together while also using a global OCIO view. By setting the working_space to "raw" on the unmanaged clips, the OCIO view will be disregarded without complaint.