### PR TITLE
fix(docs): Correct broken build guide links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ This release of xSTUDIO can be built on various Linux flavours, Microsoft Window
 
 ### Building xSTUDIO for Linux
 
-* [Linux Generic](docs/build_guides/linux_generic.md) 
-* [CentOS 7](docs/build_guides/centos_7.md)
-* [Rocky Linux 9.1](docs/build_guides/rocky_linux_9_1.md)
-* [Ubuntu 22.04](docs/build_guides/ubuntu_22_04.md)
+* [Linux Generic](docs/reference/build_guides/linux_generic.md)
+* [CentOS 7](docs/reference/build_guides/centos_7.md)
+* [Rocky Linux 9.1](docs/reference/build_guides/rocky_linux_9_1.md)
+* [Ubuntu 22.04](docs/reference/build_guides/ubuntu_22_04.md)
 
 ### Building xSTUDIO for Windows 10 & 11
 
-* [Windows](docs/build_guides/windows.md)
+* [Windows](docs/reference/build_guides/windows.md)
 
 ### Building xSTUDIO for MacOS
 
-* [MacOS](docs/build_guides/macos.md)
+* [MacOS](docs/reference/build_guides/macos.md)
 
 ### Documentation Note
 


### PR DESCRIPTION
The build guides were moved to docs/reference/build_guides/ but the README still referenced the old docs/build_guides/ path, resulting in 404 errors when users clicked the links.

<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.