### PR TITLE
#188: Fix environment variable path separator on Windows

### DIFF
--- a/src/global_store/src/global_store.cpp
+++ b/src/global_store/src/global_store.cpp
@@ -88,7 +88,12 @@ bool xstudio::global_store::load_preferences(
     // folders
     char *plugin_path = std::getenv("XSTUDIO_PLUGIN_PATH");
     if (plugin_path) {
-        for (const auto &p : xstudio::utility::split(plugin_path, ':')) {
+#ifdef _WIN32
+        char path_env_var_sep = ';';
+#else
+        char path_env_var_sep = ':';
+#endif
+        for (const auto &p : xstudio::utility::split(plugin_path, path_env_var_sep)) {
             if (fs::is_directory(p + "/preferences"))
                 preference_load_defaults(prefs, p + "/preferences");
         }

--- a/src/plugin_manager/src/plugin_manager_actor.cpp
+++ b/src/plugin_manager/src/plugin_manager_actor.cpp
@@ -30,7 +30,12 @@ PluginManagerActor::PluginManagerActor(caf::actor_config &cfg) : caf::event_base
     // xstudio plugins
     char *plugin_path = std::getenv("XSTUDIO_PLUGIN_PATH");
     if (plugin_path) {
-        for (const auto &p : xstudio::utility::split(plugin_path, ':')) {
+#ifdef _WIN32
+        char path_env_var_sep = ';';
+#else
+        char path_env_var_sep = ':';
+#endif
+        for (const auto &p : xstudio::utility::split(plugin_path, path_env_var_sep)) {
             manager_.emplace_front_path(p);
         }
     }

--- a/src/ui/qml/studio/src/qml_setup.cpp
+++ b/src/ui/qml/studio/src/qml_setup.cpp
@@ -131,7 +131,12 @@ void xstudio::ui::qml::setup_xstudio_qml_emgine(QQmlEngine *engine, caf::actor_s
     // with plugins
     char *plugin_path = std::getenv("XSTUDIO_PLUGIN_PATH");
     if (plugin_path) {
-        for (const auto &p : xstudio::utility::split(plugin_path, ':')) {
+#ifdef _WIN32
+        char path_env_var_sep = ';';
+#else
+        char path_env_var_sep = ':';
+#endif
+        for (const auto &p : xstudio::utility::split(plugin_path, path_env_var_sep)) {
 
             // note - some xSTUDIO plugins have the backend plugin component
             // and a Qt/QML plugin component built into the same binary.


### PR DESCRIPTION
Fixes #188 

This ensure that the `XSTUDIO_PLUGIN_PATH` environment variable on Windows is split on ';' rather than ':'. Splitting on ':' causes issues with windows drive specifiers (e.g. `D:/dev/xstudio_plugin` is treated as 2 paths - `D` and `/dev/xstudio_plugin`)

I've tested this on Windows, and it correctly uses the plugin path now.
