### PR TITLE
Fix for [ #193 ] viewer goes black if the window is dragged from one screen to another.

### DIFF
--- a/include/xstudio/ui/qml/qml_viewport.hpp
+++ b/include/xstudio/ui/qml/qml_viewport.hpp
@@ -85,6 +85,7 @@ namespace ui {
             void keyReleaseEvent(QKeyEvent *event) override;
 
           public slots:
+            void initRenderer();
 
             void sync();
             void cleanup();
@@ -140,6 +141,7 @@ namespace ui {
             void hasOverlaysChanged();
 
           private:
+            void createRenderer();
             void releaseResources() override;
 
             void sendPointerEvent(EventType t, QMouseEvent *event, int force_modifiers = 0);
@@ -158,6 +160,7 @@ namespace ui {
             bool has_overlays_ = {true};
 
             caf::actor keypress_monitor_;
+            caf::actor m_playhead;
         };
 
     } // namespace qml

--- a/src/ui/qml/viewport/src/qml_viewport.cpp
+++ b/src/ui/qml/viewport/src/qml_viewport.cpp
@@ -64,12 +64,30 @@ int qtModifierToOurs(const Qt::KeyboardModifiers qt_modifiers) {
 QMLViewport::QMLViewport(QQuickItem *parent) : QQuickItem(parent), cursor_(Qt::ArrowCursor) {
 
     connect(this, &QQuickItem::windowChanged, this, &QMLViewport::handleWindowChanged);
-    static int index = 0;
-
-    renderer_actor = new QMLViewportRenderer(this);
 
     keypress_monitor_ = CafSystemObject::get_actor_system().registry().template get<caf::actor>(
         xstudio::keyboard_events);
+
+    connect(this, SIGNAL(visibleChanged()), this, SLOT(onVisibleChanged()));
+
+    setAcceptedMouseButtons(Qt::AllButtons);
+    setAcceptHoverEvents(true);
+
+    createRenderer();
+}
+
+void QMLViewport::initRenderer() {
+    if (!renderer_actor) {
+        spdlog::info("QMLViewport::initRenderer recreating renderer");
+        createRenderer();
+    }
+}
+
+void QMLViewport::createRenderer() {
+    if (renderer_actor)
+        return;
+
+    renderer_actor = new QMLViewportRenderer(this);
 
     connect(
         renderer_actor,
@@ -104,20 +122,40 @@ QMLViewport::QMLViewport(QQuickItem *parent) : QQuickItem(parent), cursor_(Qt::A
         this,
         SIGNAL(snapshotRequestResult(QString)));
 
-    connect(this, SIGNAL(visibleChanged()), this, SLOT(onVisibleChanged()));
-
-    setAcceptedMouseButtons(Qt::AllButtons);
-    setAcceptHoverEvents(true);
-
     if (renderer_actor)
         renderer_actor->visibleChanged(isVisible());
+
+    if (window()) {
+        connect(
+            window(),
+            &QQuickWindow::frameSwapped,
+            renderer_actor,
+            &QMLViewportRenderer::frameSwapped,
+            Qt::DirectConnection);
+
+        connect(
+            renderer_actor, &QMLViewportRenderer::doRedraw, window(), &QQuickWindow::update);
+
+        renderer_actor->setWindow(window());
+        
+        // Reset connected state so sync() will reconnect the render loop signal
+        connected_ = false; 
+    }
+
+    // Restore state
+    renderer_actor->setIsQuickViewer(is_quickview_);
+    renderer_actor->setHasOverlays(has_overlays_);
+    if (m_playhead) renderer_actor->set_playhead(m_playhead);
+    
+    emit nameChanged();
+    emit playheadUuidChanged(); // Ensure bindings update
 }
 
 QMLViewport::~QMLViewport() { delete renderer_actor; }
 
 void QMLViewport::handleWindowChanged(QQuickWindow *win) {
 
-    spdlog::debug("QMLViewport::handleWindowChanged");
+    spdlog::info("QMLViewport::handleWindowChanged");
     if (win) {
         // Send screen info for the first time
         QScreen *screen = win->screen();
@@ -135,6 +173,13 @@ void QMLViewport::handleWindowChanged(QQuickWindow *win) {
             &QQuickWindow::sceneGraphInvalidated,
             this,
             &QMLViewport::cleanup,
+            Qt::DirectConnection);
+
+        connect(
+            win,
+            &QQuickWindow::sceneGraphInitialized,
+            this,
+            &QMLViewport::initRenderer,
             Qt::DirectConnection);
 
         connect(
@@ -166,7 +211,18 @@ void QMLViewport::handleWindowChanged(QQuickWindow *win) {
 
 void QMLViewport::handleScreenChanged(QScreen *screen) {
 
-    spdlog::debug("QMLViewport::handleScreenChanged");
+    spdlog::info("QMLViewport::handleScreenChanged {}", StdFromQString(screen->name()));
+    
+    // If we have a renderer, destroy and recreate it.
+    // This is necessary because on some platforms (macOS), moving screens can change
+    // the underlying OpenGL context/pixel format without firing sceneGraphInvalidated,
+    // leaving us with invalid shared resources (VAOs).
+    if (renderer_actor) {
+        spdlog::info("Forcing renderer recreation on screen change");
+        cleanup();
+        initRenderer();
+    }
+
     if (renderer_actor)
         renderer_actor->setScreenInfos(
             screen->name(),
@@ -258,7 +314,7 @@ void QMLViewport::setHasOverlays(const bool hasOverlays) {
 
 void QMLViewport::cleanup() {
 
-    spdlog::debug("QMLViewport::cleanup");
+    spdlog::info("QMLViewport::cleanup");
     if (renderer_actor) {
         // delete renderer_actor;
         delete renderer_actor;
@@ -522,8 +578,11 @@ void QMLViewport::setPlayhead(const QString actorAddress) {
     if (actorAddress != "") {
         caf::actor playhead =
             actorFromQString(CafSystemObject::get_actor_system(), actorAddress);
-        if (playhead && renderer_actor) {
-            renderer_actor->set_playhead(playhead);
+        if (playhead) {
+             m_playhead = playhead;
+             if (renderer_actor) {
+                 renderer_actor->set_playhead(playhead);
+             }
         } else {
             spdlog::warn(
                 "{} bad playhead actor address: {}",


### PR DESCRIPTION
## Pull Request Osx drag window across screen fix.
[ #193 ] This addresses the issue where the viewer goes black if the window is dragged from one screen to another.

## Summarize your change.
The playlist window appears to be configured for a single screen, when you drag the window from one screen to another it will go black, if you drag it back it will become visible again.

I'm using the OnVisibleChanged signal to catch that something has happened, and reinitialize the viewport.

## Describe what you have tested and on which operating system.
This has only been tested on OSX, I do not know if there might be issues on windows or linux.

## Add a list of changes, and note any that might need special attention during the review.
This seems to work, but while I have a fair bit of experience with PySide I don't have experience with these frameworks, so I could be missing something. There is some logging code, that could go, but it seems like it would be useful for testing on other platforms.