### PR TITLE
Fix event subscription to use event_group instead of event_source.remote

### DIFF
--- a/python/src/xstudio/api/module.py
+++ b/python/src/xstudio/api/module.py
@@ -389,7 +389,7 @@ class ModuleBase(ActorConnection, metaclass=ModuleMeta):
             raise Exception("Actor has no event group.")
 
         return self.connection.link.add_message_callback(
-            event_source.remote, callback_method
+            event_group, callback_method
             )
 
     def unsubscribe_from_event_group(self, uuid):


### PR DESCRIPTION
### Fix subscribe_to_event_group() registering callback on wrong actor

## Summary

`ModuleBase.subscribe_to_event_group()` registers the callback on `event_source.remote` instead of the retrieved `event_group`, causing event callbacks to never fire.

Updated PR with a recent rebase on develop branch

## The Bug

In `module.py` line 391:

```python
def subscribe_to_event_group(self, event_source, callback_method):
    event_group = self.connection.request_receive(event_source.remote, get_event_group_atom())[0]
    return self.connection.link.add_message_callback(event_source.remote, callback_method)
    #                                                ^^^^^^^^^^^^^^^^^^^ BUG: should be event_group
```

The method correctly retrieves the `event_group` actor but then ignores it, registering the callback on `event_source.remote` instead.

## The Fix

```python
def subscribe_to_event_group(self, event_source, callback_method):
    event_group = self.connection.request_receive(event_source.remote, get_event_group_atom())[0]
    return self.connection.link.add_message_callback(event_group, callback_method)
    #                                                ^^^^^^^^^^^^ FIXED: use event_group
```

## Impact

- **Before:** Event subscriptions via `subscribe_to_event_group()` were non-functional. Callbacks were registered on the wrong actor and events were never delivered.
- **After:** Event subscriptions work as intended. Callbacks receive events from the event group.

## Discovery

Found while implementing event-driven bookmark detection in a Python plugin. Studio-level session events were not being received despite successful subscription. Tracing the issue revealed the callback was registered on the wrong actor.


