### PR TITLE
Drag-n-drop improvements

### DIFF
--- a/include/xstudio/ui/qml/helper_ui.hpp
+++ b/include/xstudio/ui/qml/helper_ui.hpp
@@ -40,6 +40,7 @@ CAF_PUSH_WARNINGS
 #include <QString>
 #include <QtConcurrent>
 #include <QUrl>
+#include <QQuickItemGrabResult>
 #include <QUuid>
 
 CAF_POP_WARNINGS
@@ -583,6 +584,22 @@ namespace ui {
                         QGuiApplication::setOverrideCursor(
                             QCursor(QPixmap(name).scaledToWidth(32, Qt::SmoothTransformation)));
                 }
+            }
+
+            // alternate version taking an ItemGrabResult
+            Q_INVOKABLE void setOverrideCursor(QObject *i) {
+                if (i) {
+                    const auto item = qobject_cast<QQuickItemGrabResult*>(i);
+                    if (item) {
+                        const auto qi = item->image();
+                        const auto qp = QPixmap::fromImage(qi);
+
+                        auto qc = QCursor(qp);
+                        QGuiApplication::setOverrideCursor(qc);
+                        return;
+                    }
+                }
+                restoreOverrideCursor();
             }
 
             Q_INVOKABLE void restoreOverrideCursor() {

--- a/ui/qml/xstudio/assets/cursors/drag_cursor.svg
+++ b/ui/qml/xstudio/assets/cursors/drag_cursor.svg
@@ -1,0 +1,1 @@
+<svg height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" transform="translate(10 7)"><path d="m6.148 18.473 1.863-1.003 1.615-.839-2.568-4.816h4.332l-11.379-11.408v16.015l3.316-3.221z" fill="#fff"/><path d="m6.431 17 1.765-.941-2.775-5.202h3.604l-8.025-8.043v11.188l2.53-2.442z" fill="#000"/></g></svg>

--- a/ui/qml/xstudio/layout_framework/XsDragDropHandler.qml
+++ b/ui/qml/xstudio/layout_framework/XsDragDropHandler.qml
@@ -18,13 +18,16 @@ Item {
     signal dragExited()
     signal dragEnded()
 
-    function startDrag(mouseX, mouseY) {
+    function startDrag(mouseX, mouseY, item=null) {
         dragStartPosition = targetWidget.mapToItem(
             appWindow.contentItem,
             mouseX,
             mouseY
             )
         dragging = false
+
+        global_drag_drop_handler.dragItem = item
+        global_drag_drop_handler.dragCount = dragData.length
     }
 
     property bool dragging: false
@@ -54,7 +57,7 @@ Item {
             mouseY
             )
 
-        if (!dragging) {
+        if (!dragging && dragStartPosition != undefined) {
             // drag only starts whne the mouse has moved by dragThresholdPixels
             var dx = dragMousePosition.x-dragStartPosition.x
             var dy = dragMousePosition.y-dragStartPosition.y

--- a/ui/qml/xstudio/qml.qrc
+++ b/ui/qml/xstudio/qml.qrc
@@ -284,6 +284,7 @@
 
 	<qresource prefix="/cursors">
 		<file alias="magnifier_cursor.svg">assets/cursors/magnifier_cursor.svg</file>
+		<file alias="drag_cursor.svg">assets/cursors/drag_cursor.svg</file>
 		<file alias="colour_picker_cursor.svg">assets/icons/dropper.svg</file>
 		<file alias="point_scan.svg">assets/icons/point_scan.svg</file>
 	</qresource>

--- a/ui/qml/xstudio/views/media/grid_view/delegates/XsMediaGridItemDelegate.qml
+++ b/ui/qml/xstudio/views/media/grid_view/delegates/XsMediaGridItemDelegate.qml
@@ -127,16 +127,6 @@ Rectangle{
         visible: isDragTarget
         z: 11
     }
-    Rectangle {
-        id: drag_item_bg
-        anchors.fill: parent
-        visible: dragTargetIndex != undefined && isSelected
-        opacity: 0.5
-        color: "white"
-        z: 10
-    }
-
-
 
     ColumnLayout{ id: tileItems
         width: isDragTarget? parent.width-drag_target_indicator.width-drag_target_indicator.anchors.rightMargin

--- a/ui/qml/xstudio/views/media/list_view/delegates/XsMediaItemDelegate.qml
+++ b/ui/qml/xstudio/views/media/list_view/delegates/XsMediaItemDelegate.qml
@@ -92,15 +92,6 @@ Rectangle {
         y: dragToEnd ? parent.height-height : 0
     }
 
-    Rectangle {
-        id: drag_item_bg
-        anchors.fill: parent
-        visible: dragTargetIndex != undefined && isSelected
-        opacity: 0.5
-        color: "white"
-        z: 100
-    }
-
     property var mediaSourceMetadataFields: mediaDisplayInfoRole
 
     property bool fieldsReady: typeof mediaSourceMetadataFields == "object"

--- a/ui/qml/xstudio/views/media/widgets/XsMediaListMouseArea.qml
+++ b/ui/qml/xstudio/views/media/widgets/XsMediaListMouseArea.qml
@@ -68,7 +68,7 @@ MouseArea {
             }
 
             if (underMouseItem && mouse.button == Qt.LeftButton) {
-                drag_drop_handler.startDrag(mouseX, mouseY)
+                drag_drop_handler.startDrag(mouseX, mouseY, underMouseItem)
             }
 
         }


### PR DESCRIPTION
This adds support for a visual indicator both of what is being dragged as well as the number of items being dragged (for media items only).

It also fixes some issues with the current system. This includes stray drag indicators being left behind, runaway scrolling, and inadvertent reordering of media when an item is dropped on itself.

Note that the visual indicator is implemented by changing the system cursor to an image grabbed from the item under the cursor when the drag is initiated. I tried to get this working both by using a Drag attached property as well as instantiating a QDrag object in C++. In both cases it worked visually but the interface stopped receiving drag events and I couldn't figure out how to get that working. Because of this, you still cannot drag anything outside of xSTUDIO which I would like to be able to do in the future.