### PR TITLE
Allow for custom mime-data when pasteing from the clipboard

### DIFF
--- a/ui/qml/xstudio/windows/main_menu_bar/file_menu/XsFileFunctions.qml
+++ b/ui/qml/xstudio/windows/main_menu_bar/file_menu/XsFileFunctions.qml
@@ -325,12 +325,14 @@ Item {
     }
 
     function addMediaFromClipboard() {
-        if(clipboard.text.length) {
+        if (clipboard.data) {
             var index = sessionSelectionModel.currentIndex
             if (!index.valid) {
                 index = theSessionData.createPlaylist("Add Media")
+            } else if (mediaSelectionModel.selectedIndexes.length) {
+                index = mediaSelectionModel.selectedIndexes[0]
             }
-            Future.promise(index.model.handleDropFuture(Qt.CopyAction, {"text/plain": clipboard.text}, index)).then(function(quuids){
+            Future.promise(index.model.handleDropFuture(Qt.CopyAction, clipboard.data, index)).then(function(quuids){
                 mediaSelectionModel.selectFirstNewMedia(index, quuids)
             })
         }


### PR DESCRIPTION
Dragging-n-dropping currently supports custom mime-data, but pasteing from the clipboard does not (that I could get working). This PR adds support for this.

This was tested under MacOS.