### PR TITLE
Fix for an occaisional crash when swapping a media_source's URI

### DIFF
--- a/src/media/src/media_source_actor.cpp
+++ b/src/media/src/media_source_actor.cpp
@@ -1425,6 +1425,10 @@ void MediaSourceActor::get_media_pointers_for_frames(
                         .then(
                             [=](const StreamDetail &detail) mutable {
                                 // get the transform matrix for the stream
+                                if (!media_streams_.contains(base_.current(media_type))) {
+                                    rp.deliver(make_error(xstudio_error::error, "No streams"));
+                                    return;
+                                }
                                 mail(transform_matrix_atom_v)
                                     .request(
                                         media_streams_.at(base_.current(media_type)), infinite)


### PR DESCRIPTION
This fixes an occasional crash I was getting when changing the URI on the currenly viewed media_source. The crash was caused by an uncaught exception on line 1430 where `media_streams_.at(base_.current(media_type))` is called. The existence of that entry is tested in the calling lambda but it was changing before this attempt at accessing it.

Repeating the test seemed to be the safest fix although there are other ways of addressing this.