### PR TITLE
Windows command wrappers

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -58,12 +58,23 @@ if(NOT APPLE)
                 DESTINATION lib/python/)
         endif()
 
-        install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio-control
-            DESTINATION bin)
-        install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio-inject
-            DESTINATION bin)
-        install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudiopy
-            DESTINATION bin)
+        if(WIN32)
+            # Windows: install .cmd wrappers (extensionless scripts don't work on Windows)
+            install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio-control.cmd
+                DESTINATION bin)
+            install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio-inject.cmd
+                DESTINATION bin)
+            install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudiopy.cmd
+                DESTINATION bin)
+        else()
+            # Linux/macOS: install shell scripts
+            install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio-control
+                DESTINATION bin)
+            install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio-inject
+                DESTINATION bin)
+            install(PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudiopy
+                DESTINATION bin)
+        endif()
      endif()
 endif()
 

--- a/python/src/xstudio-control.cmd
+++ b/python/src/xstudio-control.cmd
@@ -1,0 +1,3 @@
+@echo off
+set PYTHONPATH=%~dp0python3\Lib\site-packages
+"%~dp0python3\python.exe" -m xstudio.cli.control %*

--- a/python/src/xstudio-inject.cmd
+++ b/python/src/xstudio-inject.cmd
@@ -1,0 +1,3 @@
+@echo off
+set PYTHONPATH=%~dp0python3\Lib\site-packages
+"%~dp0python3\python.exe" -m xstudio.cli.inject %*

--- a/python/src/xstudiopy.cmd
+++ b/python/src/xstudiopy.cmd
@@ -1,0 +1,4 @@
+@echo off
+set PYTHONPATH=%~dp0python3\Lib\site-packages
+set PYTHONSTARTUP=%~dp0python3\Lib\site-packages\xstudio\cli\xstudiopy_startup.py
+"%~dp0python3\python.exe" %*

--- a/src/launch/xstudio/src/CMakeLists.txt
+++ b/src/launch/xstudio/src/CMakeLists.txt
@@ -39,9 +39,7 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 
 configure_file(.clang-tidy .clang-tidy)
 
-if(WIN32)
-	configure_file(xstudio.bat.in xstudio.bat)
-else()
+if(NOT WIN32)
 	configure_file(xstudio.sh.in xstudio.sh @ONLY)
 endif()
 
@@ -105,11 +103,6 @@ if(WIN32)
 
 	install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin)
-
-	install(PROGRAMS
-	  ${CMAKE_CURRENT_BINARY_DIR}/xstudio.bat
-	  DESTINATION bin
-	  RENAME xstudio)
 
 	# install FFMPEG and all dependencies into target bin folder
 	file(GLOB FFMPEG_COMPONENTS ${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/tools/ffmpeg/*)


### PR DESCRIPTION
### Linked issues
Fixes #211 

### Summarize your change.

- Add .cmd batch wrappers for xstudio-control, xstudio-inject, and xstudiopy so the Python CLI tools work on Windows 
- Remove the non-functional xstudio.bat.in template, which contained Linux-only constructs (LD_LIBRARY_PATH, xstudio_desktop_integration)


### Describe the reason for the change.
Better windows support

### Describe what you have tested and on which operating system.
Tested on win/lin
