### PR TITLE
Windows path fixes

### DIFF
--- a/python/src/xstudio/connection/__init__.py
+++ b/python/src/xstudio/connection/__init__.py
@@ -587,6 +587,7 @@ class Connection(object):
             path (str): Path to a directory on filesystem
         """
 
+        path = path.strip()
         if not os.path.isdir(path):
             # silently ignore invalid paths, this is accepted behaviour for
             # search path mechanisms

--- a/python/src/xstudio/connection/__init__.py
+++ b/python/src/xstudio/connection/__init__.py
@@ -549,7 +549,7 @@ class Connection(object):
         XSTUDIO_PYTHON_PLUGIN_PATH
         """
         if "XSTUDIO_PYTHON_PLUGIN_PATH" in os.environ:
-            search_paths = os.environ["XSTUDIO_PYTHON_PLUGIN_PATH"].split(":")
+            search_paths = os.environ["XSTUDIO_PYTHON_PLUGIN_PATH"].split(os.pathsep)
             for search_path in search_paths:
                 self.load_plugins_in_path(search_path)
 

--- a/src/utility/src/frame_list.cpp
+++ b/src/utility/src/frame_list.cpp
@@ -273,7 +273,7 @@ xstudio::utility::frame_groups_from_sequence_spec(const caf::uri &from_path) {
                 continue;
             }
 #ifdef _WIN32
-            auto entryPath = entry.path().string(); // Convert to std::string
+            auto entryPath = entry.path().generic_string();
 #else
             auto entryPath = entry.path().c_str();
 #endif

--- a/src/utility/src/helpers.cpp
+++ b/src/utility/src/helpers.cpp
@@ -605,6 +605,14 @@ caf::uri xstudio::utility::posix_path_to_uri(const std::string &path, const bool
     }
 #endif
 
+#ifdef _WIN32
+    // Normalize Windows drive-letter paths (e.g. R:\foo) to valid file URIs
+    std::replace(p.begin(), p.end(), '\\', '/');
+    if (p.size() >= 2 && std::isalpha(static_cast<unsigned char>(p[0])) && p[1] == ':') {
+        p = "/" + p;
+    }
+#endif
+
     // relative
     if (not p.empty() && p[0] != '/')
         return caf::uri_builder().scheme("file").path(p).make();


### PR DESCRIPTION


### Linked issues

Fixes #213
Fixes #110

### Summarize your change.

Windows Path fixes, issues with UNC, Drive letters, and XSTUDIO_PYTHON_PLUGIN_PATH


### Describe the reason for the change.
Better windows support


### Describe what you have tested and on which operating system.
lin/win


### Add a list of changes, and note any that might need special attention during the review.

- Fix drive-letter paths (C:\foo) producing malformed file URIs — normalise backslashes and prepend leading / to produce correct file:///C:/foo URIs
- Add proper UNC path support (\\server\share\path ↔ file://server/share/path) for network share drag-and-drop
- Fix frame sequence scanning using backslashes that fail to match URI-decoded forward-slash paths
- Use os.pathsep instead of hardcoded : for plugin path splitting in XSTUDIO_PYTHON_PLUGIN_PATH
- Strip whitespace from plugin search paths 
- bugfix for a path bug in reverse_remap_file_paths was called on the original data rather than the already altered version


