### PR TITLE
ninja build for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ python/src/xstudio/version.py
 /build/
 xstudio_install/
 **/qml/*_qml_export.h
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,16 @@ option(BUILD_PYSIDE_WIDGETS "Build xstudio player as PySide widget" OFF)
 option(OPENIMAGEIO_PLUGIN "Include the OpenImageIO PLugin" ON)
 
 if(WIN32)
-  set(USE_VCPKG ON)
-  #include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/vcpkg.cmake)
-  set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Ob0 /Od /Oy-")
-  add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
-  # enable UUID System Generator
-  add_definitions(-DUUID_SYSTEM_GENERATOR=ON)
+    set(USE_VCPKG ON)
+    #include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/vcpkg.cmake)
+    set(CMAKE_CXX_FLAGS_DEBUG "/Zi /Ob0 /Od /Oy-")
+    # /MP is for MSBuild which parallelizes at project level.
+    # Ninja parallelizes at file level, so /MP would over-subscribe CPUs.
+    if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
+        add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/MP>)
+    endif()
+    # enable UUID System Generator
+    add_definitions(-DUUID_SYSTEM_GENERATOR=ON)
 endif()
 
 set(STUDIO_PLUGINS "" CACHE STRING "Enable compilation of SITE plugins")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,6 +49,39 @@
         "USE_SANITIZER": "address"
       }
     },
+    {
+      "name": "windows-ninja-base",
+      "inherits": "default",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "hidden": true,
+      "generator": "Ninja"
+    },
+    {
+      "name": "WinNinjaRelease",
+      "inherits": ["windows-ninja-base"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "WinNinjaRelWithDebInfo",
+      "inherits": ["windows-ninja-base"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "USE_SANITIZER": "address"
+      }
+    },
+    {
+      "name": "WinNinjaDebug",
+      "inherits": ["windows-ninja-base"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
     { 
       "name": "macos-base-arm",
       "condition": {

--- a/docs/reference/build_guides/windows.md
+++ b/docs/reference/build_guides/windows.md
@@ -68,3 +68,22 @@ When this has finished, you can build xSTUDIO with this command. Note the value 
 
 If the build is successful, you should have an exectuable in the 'build' folder called something like 'xSTUDIO-1.0.0-win64.exe'. This can be executed to start the xSTUDIO installer.
 
+### Alternative: Build with Ninja (faster builds)
+
+Ninja is significantly faster than MSBuild as it parallelises at the file level. Both Ninja and cmake are included with Visual Studio's CMake tools, so no separate install is needed.
+
+First, set up the Visual Studio build environment in your Powershell session. This puts the MSVC compiler, cmake and ninja on your PATH:
+
+    Import-Module "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+    Enter-VsDevShell -VsInstallPath "C:\Program Files\Microsoft Visual Studio\2022\Community" -Arch amd64
+
+Run the cmake command to configure for building. Note that this cmake command ***may take several hours to complete***. This is because xSTUDIO's dependencies (particularly ffmpeg) take a long time to download and build from the source code, which is what VCPKG is doing.
+
+    cmake -B build --preset WinNinjaRelease
+
+When this has finished, you can build xSTUDIO with this command. Ninja handles parallelism automatically so there is no need for the `--parallel` flag.
+
+    cmake --build build
+
+If the build is successful, you should have an executable in the 'build' folder called something like 'xSTUDIO-1.0.0-win64.exe'. This can be executed to start the xSTUDIO installer.
+


### PR DESCRIPTION

Hi this is a more opinionated PR. 

This changes the build to use Ninja, a faster build backend, on Windows. It is possible to use it on macOS and Linux as well for a faster and consistent build process across all platforms.

 CMakeUserPresets.json is added to .gitignore. CMake reads this file automatically alongside CMakePresets.json, allowing developers to define local presets (e.g. Ninja presets for Linux/macOS, custom Qt paths) without dirtying
  the working tree.  