### PR TITLE
feat(ui): show Gamma and Saturation controls in viewport toolbar

### DIFF
--- a/share/preference/ui_viewport.json
+++ b/share/preference/ui_viewport.json
@@ -65,7 +65,7 @@
 				"path": "/ui/viewport/hidden_toolbar_items",
 				"default_value": false,
 				"description": "Hides items from the viewport toolbar",
-				"value": ["Gamma", "Saturation", "Rate", "Mirror"],
+				"value": ["Rate", "Mirror"],
 				"datatype": "json",
 				"context": ["QML_UI"]
 			}


### PR DESCRIPTION
## Summary

- Remove Gamma and Saturation from the default hidden toolbar items, making them visible by default in the viewport toolbar

## Files changed

- `share/preference/ui_viewport.json` — update hidden_toolbar_items default

## Test plan

- [ ] Launch xstudio and verify Gamma and Saturation controls are visible in the viewport toolbar
- [ ] Verify Rate and Mirror remain hidden by default
- [ ] Verify existing user preferences still override the defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)