### PR TITLE
Fix for hiding drag count text

### DIFF
--- a/ui/qml/xstudio/windows/drag_drop/XsGlobalDragDropHandler.qml
+++ b/ui/qml/xstudio/windows/drag_drop/XsGlobalDragDropHandler.qml
@@ -149,6 +149,7 @@ DropArea {
             x: drag_cursor.x + drag_cursor.width
             y: drag_cursor.y + drag_cursor.height - height/2
             color: "#FFF00000"
+            clip: true
             //visible: dragCount > 1 // this doesn't work for some reason
 
             Text {


### PR DESCRIPTION
When only one item is being dragged, the count badge is supposed to be hidden. While the red disk does correctly hide itself the text component wasn’t. This fixes that.

<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.