### PR TITLE
Fix timeline panel not populating on session restore

### DIFF
--- a/src/ui/qml/session/src/session_model_ui.cpp
+++ b/src/ui/qml/session/src/session_model_ui.cpp
@@ -627,6 +627,17 @@ void SessionModel::processChildren(const nlohmann::json &rj, const QModelIndex &
         emit dataChanged(parent_index, parent_index, roles);
     }
 
+    // After populating session/playlist children, re-trigger the viewport and
+    // current container lookup.  On session restore the initial lookup fires
+    // before the model tree is fully built (the children arrive asynchronously),
+    // so timelines inside playlists are not yet findable.  Re-checking here
+    // ensures the timeline panel picks up the active container once its node
+    // actually exists in the tree.
+    if (type == "Session" || type == "Container List" || type == "Playlist") {
+        updateCurrentMediaContainerIndexFromBackend();
+        updateViewportCurrentMediaContainerIndexFromBackend();
+    }
+
     emit jsonChanged();
 
     CHECK_SLOW_WATCHER_FAST()

--- a/ui/qml/xstudio/views/timeline/XsTimeline.qml
+++ b/ui/qml/xstudio/views/timeline/XsTimeline.qml
@@ -306,6 +306,30 @@ Rectangle {
                     initTimeline()
                     }}(), 50);
 
+        } else if (viewedMediaSetProperties.index.valid && viewedMediaSetProperties.values.typeRole == "Playlist") {
+            // When restoring a session, the viewed container may be a Playlist
+            // rather than a Timeline.  Find the first Timeline child inside the
+            // Playlist's Container List (row 2) and initialise from it.
+            let containerListIndex = theSessionData.index(2, 0, viewedMediaSetProperties.index)
+            let childCount = theSessionData.rowCount(containerListIndex)
+            for (let i = 0; i < childCount; i++) {
+                let childIndex = theSessionData.index(i, 0, containerListIndex)
+                if (theSessionData.get(childIndex, "typeRole") == "Timeline") {
+                    // Switch the viewed container to this Timeline so the
+                    // playhead and viewport are correctly attached.
+                    theSessionData.viewportCurrentMediaContainerIndex = childIndex
+                    return
+                }
+            }
+            // No timeline children found (or not yet loaded).  If the container
+            // list is empty the data may still be arriving asynchronously, so
+            // retry after a short delay.
+            if (childCount == 0 && !timeline_items.rootIndex.valid) {
+                callbackTimer.setTimeout(function() { return function() {
+                        viewedMediaSetChanged()
+                        }}(), 250);
+            }
+
         } else if (!timeline_items.rootIndex.valid) {
             // if the user has selected something that is not a timeline (playlist,
             // subset etc.), we do  not update our index here (unless the timeline


### PR DESCRIPTION
## Summary
- **Race condition in SessionModel**: `updateViewportCurrentMediaContainerIndexFromBackend()` ran before the model tree was fully built. The async `requestData(childrenRole)` populates playlists and their timeline children progressively, but the container lookup executed before timeline nodes existed in the tree. Added a re-trigger of both container index lookups at the end of `processChildren()` when the parent type is Session, Container List, or Playlist.
- **QML timeline panel only handled `typeRole=="Timeline"`**: When the restored viewed container is a Playlist (common — the session stores the Playlist UUID, not the Timeline UUID), the timeline panel did nothing. Added a Playlist handler that finds the first Timeline child in the Playlist's Container List and switches the viewed container to it, with async retry if children haven't loaded yet.

This fixes the "Saved sessions might not restore media correctly (Windows only)" known issue from the README — though the timing bug in `processChildren` affects all platforms, not just Windows.

## Test plan
- [ ] Save a session with a timeline visible, close and re-open — timeline panel should auto-populate
- [ ] Save a session with a playlist (containing a timeline) as the active view — timeline should still appear
- [ ] Verify normal interactive timeline switching still works (click playlist → click timeline within it)
- [ ] Test on both Windows and Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)