### PR TITLE
Add annotation onion skinning viewport overlay plugin

### DIFF
--- a/include/xstudio/ui/canvas/stroke.hpp
+++ b/include/xstudio/ui/canvas/stroke.hpp
@@ -77,6 +77,8 @@ namespace ui {
             bool fade(const float fade_amount);
 
             [[nodiscard]] float opacity() const { return _opacity; }
+            void set_opacity(const float o) { _opacity = o; }
+            void set_colour(const utility::ColourTriplet &c) { _colour = c; }
             [[nodiscard]] float thickness() const { return _thickness; }
             [[nodiscard]] float softness() const { return _softness; }
             [[nodiscard]] float size_sensitivity() const { return _size_sensitivity; }

--- a/src/plugin/viewport_overlay/CMakeLists.txt
+++ b/src/plugin/viewport_overlay/CMakeLists.txt
@@ -2,5 +2,6 @@ add_src_and_test(basic_viewport_mask)
 add_src_and_test(annotations)
 add_src_and_test(audio_waveform)
 add_src_and_test(media_metadata_hud)
+add_src_and_test(annotation_onion_skin)
 
 build_studio_plugins("${STUDIO_PLUGINS}")

--- a/src/plugin/viewport_overlay/annotation_onion_skin/src/CMakeLists.txt
+++ b/src/plugin/viewport_overlay/annotation_onion_skin/src/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+SET(LINK_DEPS
+	xstudio::module
+	xstudio::plugin_manager
+	xstudio::ui::opengl::viewport
+	Imath::Imath
+)
+
+find_package(Imath)
+
+create_plugin_with_alias(
+	annotation_onion_skin
+	xstudio::viewport::annotation_onion_skin
+	${XSTUDIO_GLOBAL_VERSION}
+	"${LINK_DEPS}")

--- a/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_plugin.cpp
+++ b/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_plugin.cpp
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "onion_skin_plugin.hpp"
+#include "onion_skin_render_data.hpp"
+#include "onion_skin_renderer.hpp"
+#include "xstudio/media_reader/image_buffer.hpp"
+#include "xstudio/bookmark/bookmark.hpp"
+#include "xstudio/plugin_manager/plugin_base.hpp"
+#include "xstudio/utility/blind_data.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <variant>
+
+using namespace xstudio;
+using namespace xstudio::ui::viewport;
+
+OnionSkinPlugin::OnionSkinPlugin(
+    caf::actor_config &cfg, const utility::JsonStore &init_settings)
+    : plugin::HUDPluginBase(cfg, "Annotation Onion Skin", init_settings, 10.0f) {
+
+    frames_before_ = add_integer_attribute("Frames Before", "Before", 3, 0, 20);
+    add_hud_settings_attribute(frames_before_);
+    frames_before_->set_tool_tip(
+        "Maximum frame distance to look back for annotations");
+    frames_before_->set_redraw_viewport_on_change(true);
+
+    frames_after_ = add_integer_attribute("Frames After", "After", 3, 0, 20);
+    add_hud_settings_attribute(frames_after_);
+    frames_after_->set_tool_tip(
+        "Maximum frame distance to look ahead for annotations");
+    frames_after_->set_redraw_viewport_on_change(true);
+
+    base_opacity_ =
+        add_float_attribute("Base Opacity", "Opacity", 0.4f, 0.05f, 1.0f, 0.05f);
+    add_hud_settings_attribute(base_opacity_);
+    base_opacity_->set_tool_tip("Opacity of the nearest neighboring annotation");
+    base_opacity_->set_redraw_viewport_on_change(true);
+
+    opacity_falloff_ =
+        add_float_attribute("Opacity Falloff", "Falloff", 0.5f, 0.1f, 1.0f, 0.05f);
+    add_hud_settings_attribute(opacity_falloff_);
+    opacity_falloff_->set_tool_tip(
+        "Multiplier applied per frame step further from current frame");
+    opacity_falloff_->set_redraw_viewport_on_change(true);
+
+    use_original_colours_ = add_boolean_attribute(
+        "Use Original Colours", "Orig Colours", false);
+    add_hud_settings_attribute(use_original_colours_);
+    use_original_colours_->set_tool_tip(
+        "When enabled, keep annotation colours and only reduce opacity. "
+        "When disabled, tint with Previous/Next colours.");
+    use_original_colours_->set_redraw_viewport_on_change(true);
+
+    past_tint_ = add_colour_attribute(
+        "Previous Tint", "Prev Tint", utility::ColourTriplet(1.0f, 0.3f, 0.3f));
+    add_hud_settings_attribute(past_tint_);
+    past_tint_->set_tool_tip("Tint colour for annotations from previous frames");
+    past_tint_->set_redraw_viewport_on_change(true);
+
+    future_tint_ = add_colour_attribute(
+        "Next Tint", "Next Tint", utility::ColourTriplet(0.3f, 1.0f, 0.3f));
+    add_hud_settings_attribute(future_tint_);
+    future_tint_->set_tool_tip("Tint colour for annotations from future frames");
+    future_tint_->set_redraw_viewport_on_change(true);
+
+    add_hud_description(
+        "Shows annotations from neighboring frames as semi-transparent, "
+        "color-tinted overlays on the current frame.");
+
+    frames_before_->set_preference_path("/plugin/annotation_onion_skin/frames_before");
+    frames_after_->set_preference_path("/plugin/annotation_onion_skin/frames_after");
+    base_opacity_->set_preference_path("/plugin/annotation_onion_skin/base_opacity");
+    opacity_falloff_->set_preference_path("/plugin/annotation_onion_skin/opacity_falloff");
+    use_original_colours_->set_preference_path("/plugin/annotation_onion_skin/use_original_colours");
+    past_tint_->set_preference_path("/plugin/annotation_onion_skin/past_tint");
+    future_tint_->set_preference_path("/plugin/annotation_onion_skin/future_tint");
+}
+
+plugin::ViewportOverlayRendererPtr
+OnionSkinPlugin::make_overlay_renderer(const std::string & /*viewport_name*/) {
+    return plugin::ViewportOverlayRendererPtr(new OnionSkinRenderer());
+}
+
+utility::BlindDataObjectPtr OnionSkinPlugin::onscreen_render_data(
+    const media_reader::ImageBufPtr &image,
+    const std::string & /*viewport_name*/,
+    const utility::Uuid & /*playhead_uuid*/,
+    const bool /*is_hero_image*/,
+    const bool /*images_are_in_grid_layout*/) const {
+
+    if (!visible() || !image)
+        return {};
+
+    const int current_frame   = image.playhead_logical_frame();
+    const int range_before    = static_cast<int>(frames_before_->value());
+    const int range_after     = static_cast<int>(frames_after_->value());
+    const float base_opac     = base_opacity_->value();
+    const float falloff       = opacity_falloff_->value();
+    const bool orig_colours   = use_original_colours_->value();
+    const auto &prev_colour   = past_tint_->value();
+    const auto &next_colour   = future_tint_->value();
+
+    if (range_before == 0 && range_after == 0)
+        return {};
+
+    // ── Update bookmark cache ──
+    // image.bookmarks() carries bookmarks covering the current frame.
+    // We cache them keyed by logical frame to find neighbors later.
+    //
+    // Invalidation: when revisiting a frame, if its bookmarks changed
+    // (different UUIDs or count), we clear the entire cache. This handles
+    // bookmark deletion, media changes, and bookmark additions.
+    const auto &frame_bookmarks = image.bookmarks();
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+
+        auto it = frame_bookmark_cache_.find(current_frame);
+        if (it != frame_bookmark_cache_.end()) {
+            bool changed = (it->second.size() != frame_bookmarks.size());
+            if (!changed) {
+                for (size_t i = 0; i < it->second.size(); ++i) {
+                    if (it->second[i]->detail_.uuid_ !=
+                        frame_bookmarks[i]->detail_.uuid_) {
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+            if (changed) {
+                frame_bookmark_cache_.clear();
+            }
+        }
+
+        if (!frame_bookmarks.empty()) {
+            frame_bookmark_cache_[current_frame] = frame_bookmarks;
+        } else {
+            frame_bookmark_cache_.erase(current_frame);
+        }
+    }
+
+    // Collect current frame's annotation pointers — skip these when
+    // walking neighbors (same annotation spans multiple frames).
+    std::set<const void *> current_annotations;
+    for (const auto &bm : frame_bookmarks) {
+        if (bm && bm->annotation_ && bm->annotation_->user_data())
+            current_annotations.insert(bm->annotation_->user_data());
+    }
+
+    // ── Helpers ──
+    auto tint_colour = [](const utility::ColourTriplet &c,
+                          const utility::ColourTriplet &tint) -> utility::ColourTriplet {
+        return {c.r * tint.r, c.g * tint.g, c.b * tint.b};
+    };
+
+    auto make_canvas_copy = [&](const ui::canvas::Canvas &src, float opacity,
+                                const utility::ColourTriplet &tint,
+                                bool keep_original) -> ui::canvas::Canvas {
+        ui::canvas::Canvas out(src);
+        for (auto it = out.begin(); it != out.end(); ++it) {
+            auto item = *it;
+            std::visit(
+                [&](auto &v) {
+                    using T = std::decay_t<decltype(v)>;
+                    if constexpr (std::is_same_v<T, ui::canvas::Stroke>) {
+                        v.set_opacity(v.opacity() * opacity);
+                        if (!keep_original)
+                            v.set_colour(tint_colour(v.colour(), tint));
+                    } else if constexpr (std::is_same_v<T, ui::canvas::Caption>) {
+                        v.set_opacity(v.opacity() * opacity);
+                        v.set_bg_opacity(v.background_opacity() * opacity);
+                        if (!keep_original)
+                            v.set_colour(tint_colour(v.colour(), tint));
+                    } else {
+                        v.opacity *= opacity;
+                        if (!keep_original)
+                            v.colour = tint_colour(v.colour, tint);
+                    }
+                },
+                item);
+            out.overwrite_item(it, item);
+        }
+        return out;
+    };
+
+    // Opacity falls off with distance: nearest = base_opac, farther = less.
+    auto compute_opacity = [&](int distance) -> float {
+        return base_opac * std::pow(falloff, static_cast<float>(distance - 1));
+    };
+
+    // ── Find neighbor annotations from cache (distance-bounded) ──
+    struct Candidate {
+        const ui::canvas::Canvas *canvas;
+        int abs_distance;
+        float opacity;
+        utility::ColourTriplet tint;
+    };
+    std::vector<Candidate> candidates;
+
+    {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+
+        // Walk backward — stop when distance exceeds range_before.
+        if (range_before > 0) {
+            auto it = frame_bookmark_cache_.lower_bound(current_frame);
+            if (it != frame_bookmark_cache_.begin()) {
+                auto pit = it;
+                while (pit != frame_bookmark_cache_.begin()) {
+                    --pit;
+                    int dist = current_frame - pit->first;
+                    if (dist > range_before)
+                        break;
+                    for (const auto &bm : pit->second) {
+                        if (!bm || !bm->annotation_ || !bm->annotation_->user_data())
+                            continue;
+                        const auto *canvas = static_cast<const ui::canvas::Canvas *>(
+                            bm->annotation_->user_data());
+                        if (!canvas || canvas->empty())
+                            continue;
+                        if (current_annotations.count(canvas))
+                            continue;
+                        candidates.push_back(
+                            {canvas, dist, compute_opacity(dist), prev_colour});
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Walk forward — stop when distance exceeds range_after.
+        if (range_after > 0) {
+            auto it = frame_bookmark_cache_.upper_bound(current_frame);
+            while (it != frame_bookmark_cache_.end()) {
+                int dist = it->first - current_frame;
+                if (dist > range_after)
+                    break;
+                for (const auto &bm : it->second) {
+                    if (!bm || !bm->annotation_ || !bm->annotation_->user_data())
+                        continue;
+                    const auto *canvas = static_cast<const ui::canvas::Canvas *>(
+                        bm->annotation_->user_data());
+                    if (!canvas || canvas->empty())
+                        continue;
+                    if (current_annotations.count(canvas))
+                        continue;
+                    candidates.push_back(
+                        {canvas, dist, compute_opacity(dist), next_colour});
+                    break;
+                }
+                ++it;
+            }
+        }
+    }
+
+    if (candidates.empty())
+        return {};
+
+    // Render farthest first so closest onion skin draws on top.
+    std::sort(candidates.begin(), candidates.end(),
+              [](const auto &a, const auto &b) { return a.abs_distance > b.abs_distance; });
+
+    std::vector<ui::canvas::Canvas> canvases;
+    canvases.reserve(candidates.size());
+    for (const auto &c : candidates) {
+        canvases.push_back(make_canvas_copy(*c.canvas, c.opacity, c.tint, orig_colours));
+    }
+
+    return std::make_shared<OnionSkinRenderData>(std::move(canvases));
+}
+
+
+extern "C" {
+plugin_manager::PluginFactoryCollection *plugin_factory_collection_ptr() {
+    return new plugin_manager::PluginFactoryCollection(
+        std::vector<std::shared_ptr<plugin_manager::PluginFactory>>(
+            {std::make_shared<plugin_manager::PluginFactoryTemplate<OnionSkinPlugin>>(
+                OnionSkinPlugin::PLUGIN_UUID,
+                "AnnotationOnionSkin",
+                plugin_manager::PluginFlags::PF_HEAD_UP_DISPLAY |
+                    plugin_manager::PluginFlags::PF_VIEWPORT_OVERLAY,
+                true,
+                "RodeoFX",
+                "Annotation Onion Skinning Overlay")}));
+}
+}

--- a/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_plugin.hpp
+++ b/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_plugin.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <map>
+#include <mutex>
+#include <set>
+
+#include "xstudio/bookmark/bookmark.hpp"
+#include "xstudio/plugin_manager/hud_plugin.hpp"
+#include "xstudio/ui/canvas/canvas.hpp"
+
+namespace xstudio {
+namespace ui {
+    namespace viewport {
+
+        class OnionSkinRenderer;
+
+        class OnionSkinPlugin : public plugin::HUDPluginBase {
+          public:
+            inline static const utility::Uuid PLUGIN_UUID{
+                "b7e3a1c0-5d4f-4e8b-9a2c-1f6d8e0b3c5a"};
+
+            OnionSkinPlugin(
+                caf::actor_config &cfg, const utility::JsonStore &init_settings);
+
+            ~OnionSkinPlugin() override = default;
+
+          protected:
+            utility::BlindDataObjectPtr onscreen_render_data(
+                const media_reader::ImageBufPtr &image,
+                const std::string &viewport_name,
+                const utility::Uuid &playhead_uuid,
+                const bool is_hero_image,
+                const bool images_are_in_grid_layout) const override;
+
+            plugin::ViewportOverlayRendererPtr
+            make_overlay_renderer(const std::string &viewport_name) override;
+
+          private:
+            module::IntegerAttribute *frames_before_;
+            module::IntegerAttribute *frames_after_;
+            module::FloatAttribute *base_opacity_;
+            module::FloatAttribute *opacity_falloff_;
+            module::BooleanAttribute *use_original_colours_;
+            module::ColourAttribute *past_tint_;
+            module::ColourAttribute *future_tint_;
+
+            // Bookmark cache: built from image.bookmarks() as user scrubs.
+            // Invalidated when bookmarks change (detected by comparing
+            // bookmark UUIDs for revisited frames).
+            mutable std::mutex cache_mutex_;
+            mutable std::map<int, bookmark::BookmarkAndAnnotations> frame_bookmark_cache_;
+        };
+
+    } // namespace viewport
+} // namespace ui
+} // namespace xstudio

--- a/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_render_data.hpp
+++ b/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_render_data.hpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vector>
+
+#include "xstudio/ui/canvas/canvas.hpp"
+#include "xstudio/utility/blind_data.hpp"
+
+
+namespace xstudio {
+namespace ui {
+    namespace viewport {
+
+        // Each neighbor canvas has opacity and tint baked into its items,
+        // so it can be rendered directly with no FBO compositing.
+        class OnionSkinRenderData : public utility::BlindDataObject {
+          public:
+            OnionSkinRenderData() = default;
+            explicit OnionSkinRenderData(std::vector<canvas::Canvas> c)
+                : canvases(std::move(c)) {}
+            ~OnionSkinRenderData() override = default;
+
+            std::vector<canvas::Canvas> canvases; // farthest-to-nearest order
+        };
+
+    } // namespace viewport
+} // namespace ui
+} // namespace xstudio

--- a/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_renderer.cpp
+++ b/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_renderer.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+#include "onion_skin_renderer.hpp"
+#include "onion_skin_plugin.hpp"
+#include "onion_skin_render_data.hpp"
+#include "xstudio/media_reader/image_buffer.hpp"
+#include "xstudio/utility/blind_data.hpp"
+
+using namespace xstudio;
+using namespace xstudio::ui::viewport;
+
+
+void OnionSkinRenderer::render_image_overlay(
+    const Imath::M44f &transform_window_to_viewport_space,
+    const Imath::M44f &transform_viewport_to_image_space,
+    const float viewport_du_dpixel,
+    const float device_pixel_ratio,
+    const xstudio::media_reader::ImageBufPtr &frame) {
+
+    auto blind = frame.plugin_blind_data(OnionSkinPlugin::PLUGIN_UUID);
+    const auto *render_data =
+        dynamic_cast<const OnionSkinRenderData *>(blind.get());
+    if (!render_data || render_data->canvases.empty())
+        return;
+
+    if (!canvas_renderer_)
+        canvas_renderer_ = std::make_unique<opengl::OpenGLCanvasRenderer>();
+
+    const float img_aspect = media_reader::image_aspect(frame);
+
+    // Opacity and tint are already baked into each canvas's items,
+    // so we just render them directly — no FBO needed.
+    for (const auto &canvas : render_data->canvases) {
+        canvas_renderer_->render_canvas(
+            canvas,
+            transform_window_to_viewport_space,
+            transform_viewport_to_image_space,
+            viewport_du_dpixel,
+            device_pixel_ratio,
+            img_aspect,
+            false); // don't hide strokes
+    }
+}

--- a/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_renderer.hpp
+++ b/src/plugin/viewport_overlay/annotation_onion_skin/src/onion_skin_renderer.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <memory>
+
+#include "xstudio/plugin_manager/plugin_base.hpp"
+#include "xstudio/ui/opengl/opengl_canvas_renderer.hpp"
+
+namespace xstudio {
+namespace ui {
+    namespace viewport {
+
+        class OnionSkinRenderer : public plugin::ViewportOverlayRenderer {
+
+          public:
+            OnionSkinRenderer() = default;
+
+            void render_image_overlay(
+                const Imath::M44f &transform_window_to_viewport_space,
+                const Imath::M44f &transform_viewport_to_image_space,
+                const float viewport_du_dpixel,
+                const float device_pixel_ratio,
+                const xstudio::media_reader::ImageBufPtr &frame) override;
+
+            float stack_order() const override { return 1.5f; }
+
+          private:
+            std::unique_ptr<opengl::OpenGLCanvasRenderer> canvas_renderer_;
+        };
+
+    } // namespace viewport
+} // namespace ui
+} // namespace xstudio


### PR DESCRIPTION
## Add annotation onion skinning viewport overlay plugin

### Summary

New self-contained viewport overlay plugin that displays annotations from neighboring frames as semi-transparent, color-tinted overlays on the current frame — the classic "onion skinning" technique applied to review annotations.

- Zero changes to core rendering pipeline or data structures
- Fully self-contained plugin using existing extension points (HUDPluginBase, ViewportOverlayRenderer, OpenGLCanvasRenderer)
- Canvas accessed via the public AnnotationBase::user_data() API — no dependency on the annotations plugin internals

It's a PR for issue #96 

### How it works

1. Plugin caches each frame's bookmarks as the user scrubs (keyed by logical frame)
2. For the current frame, walks the cache backward/forward to find neighboring annotated frames
3. Copies each neighbor's Canvas, bakes opacity and tint directly into stroke/caption/shape items
4. Renders modified canvases via the standard render_canvas() path — no FBO, no custom shaders
5. Stack order 1.5 places onion skins below current annotations (2.0), above the image

### What this PR does

Adds a new `annotation_onion_skin` viewport overlay plugin that renders neighboring frames' annotations with configurable opacity falloff and directional color tinting (red for past, green for future by default).

**Plugin settings** (all exposed via the HUD toolbar):

| Setting | Default | Description |
|---------|---------|-------------|
| Frames Before / After | 3 | Max frame distance to search for annotations |
| Base Opacity | 0.4 | Opacity of the nearest neighbor annotation |
| Opacity Falloff | 0.5 | Multiplier per frame step further away |
| Use Original Colours | off | Keep annotation colours and only reduce opacity |
| Previous / Next Tint | Red / Green | Directional tint when not using original colours |

### Design decisions

**Self-contained plugin, zero core changes to rendering pipeline:**
- Extends `HUDPluginBase` and `ViewportOverlayRenderer` — the same extension points used by the mask and HUD plugins
- Accesses annotation canvas data through the public `AnnotationBase::user_data()` API, with no compile-time dependency on the annotations plugin
- Renders at stack order 1.5 (below current-frame annotations at 2.0, above image)

**Baked opacity/tint instead of FBO compositing:**
- Copies neighbor canvases and modifies stroke/caption/shape opacity and colour in-place
- Renders via the existing `OpenGLCanvasRenderer::render_canvas()` path — no offscreen FBOs, no custom shaders, no GL state management issues
- This approach was chosen over FBO compositing after finding that nested FBO operations interfered with the viewport's texture pipeline on macOS

**Plugin-local bookmark cache:**
- `frame.bookmarks()` only carries bookmarks for the current frame. To find neighbors, the plugin maintains a lightweight cache (`std::map<int, BookmarkAndAnnotations>`) populated as the user scrubs
- Cache invalidation: when revisiting a frame, bookmark UUIDs are compared; if they differ, the entire cache is cleared
- This avoids any changes to `ImageBufPtr`/`SidecarData` (which would break ABI with pre-built distributions) and avoids async actor queries from the render data path

**Stroke setters:**
- Adds `set_opacity()` and `set_colour()` to `Stroke`, matching the setter pattern already established by `Caption`. These are needed to modify stroke properties in copied canvases without reconstructing the objects.

### Files

```
include/xstudio/ui/canvas/stroke.hpp                              (+2)  — Stroke setters
src/plugin/viewport_overlay/CMakeLists.txt                         (+1)  — Register plugin
src/plugin/viewport_overlay/annotation_onion_skin/
  src/CMakeLists.txt                                               (+15)
  src/onion_skin_plugin.hpp                                        (+57)
  src/onion_skin_plugin.cpp                                       (+284)
  src/onion_skin_render_data.hpp                                   (+28)
  src/onion_skin_renderer.hpp                                      (+33)
  src/onion_skin_renderer.cpp                                      (+42)
  test/CMakeLists.txt                                               (0)
```

9 files, ~460 lines added.

### Known limitation

Onion skins only appear for frames the user has already visited in the current session (the bookmark cache builds during playback and scrubbing). A future enhancement could expose all timeline bookmarks on `ImageBufPtr` to provide immediate neighbor access — this was prototyped but deferred to keep this PR free of core data structure changes.

### Testing

- Load media with 10+ frames, enable "Annotation Onion Skin" from the HUD toolbar
- Annotate several frames with distinct strokes at different positions
- Scrub through the sequence to populate the cache
- Navigate to a frame between annotated frames — verify past annotations show with red tint, future with green tint, and opacity decreases with distance
- Toggle "Use Original Colours" — annotations should keep their drawn colours
- Adjust Frames Before/After, Base Opacity, Falloff — verify live update
- Disable the HUD — verify the viewport renders normally with no overhead
- Verify existing annotation drawing and editing is unaffected
