### PR TITLE
Fix annotation export crash when viewed container is a Subset

### DIFF
--- a/src/plugin/python_plugins/annotations_exporter/annotations_exporter.py
+++ b/src/plugin/python_plugins/annotations_exporter/annotations_exporter.py
@@ -159,7 +159,7 @@ class AnnotationsExporter(PluginBase):
         if attr == self.scope:
             if self.scope.value() in ["Current Media", "Current Frame"]:
                 self.user_name.set_value(
-                    self.connection.api.session.viewed_container.playhead.on_screen_media.name
+                    self.current_playhead().on_screen_media.name
                 )
             elif self.scope.value() == "Current Playlist / Timeline":
                 self.user_name.set_value(
@@ -232,7 +232,7 @@ class AnnotationsExporter(PluginBase):
         elif scope == "Current Media":
 
             self.export_media_annotations(
-                self.connection.api.session.viewed_container.playhead.on_screen_media
+                self.current_playhead().on_screen_media
                 )
             
         elif scope == "Current Playlist / Timeline":
@@ -254,7 +254,7 @@ class AnnotationsExporter(PluginBase):
             gp_file_path = self.__output_folder + "/greasePencil.xml"
             self.make_greaspencil_xml_file(
                 gp_file_path,
-                self.connection.api.session.viewed_container.playhead.on_screen_media.media_source().rate.fps()
+                self.current_playhead().on_screen_media.media_source().rate.fps()
                 )
             # now we zip the folder
             final_name = shutil.make_archive(self.__output_folder + "/" + self.user_name.value(), 'zip', __tmp_folder)
@@ -314,8 +314,8 @@ class AnnotationsExporter(PluginBase):
 
     def export_bookmark_on_current_frame(self):
 
-        m = self.connection.api.session.viewed_container.playhead.on_screen_media
-        current_frame = self.connection.api.session.viewed_container.playhead.attributes['Media Logical Frame'].value()
+        m = self.current_playhead().on_screen_media
+        current_frame = self.current_playhead().attributes['Media Logical Frame'].value()
         bookmarks = m.ordered_bookmarks()
         bookmark = None
         for bm in bookmarks:


### PR DESCRIPTION
### Summary                                                

- The annotations exporter assumed the viewed container is always a Playlist, accessing the playhead via session.viewed_container.playhead                   
- When media is loaded into a Subset (e.g. by a Python plugin like rdo_browser), this crashes with 'Subset' object has no attribute 'playhead'
- Replace all 5 call sites with self.current_playhead(), which is provided by PluginBase and returns the active playhead regardless of container type        
                                                                                                                                                               
### Changes                                                                                                                                                      
                                                                                                                                                               
- annotations_exporter.py — replace self.connection.api.session.viewed_container.playhead with self.current_playhead() at lines 162, 235, 257, 317, 318      
   
### Test plan                                                                                                                                                    
                                                         
- Open media via a plugin that sets the viewer to a Subset
- Export annotations using each scope: Current Frame, Current Media, Current Playlist / Timeline
- Verify export completes without crash and output is correct                                                                                                
- Confirm standard Playlist-based workflow still works as before