### PR TITLE
fix(sequence): correctly detect padding for frames with no leading zeros

### DIFF
--- a/src/utility/src/sequence.cpp
+++ b/src/utility/src/sequence.cpp
@@ -344,9 +344,11 @@ std::vector<Sequence> default_collapse_sequences(const std::vector<Entry> &entri
 }
 
 int pad_size(const std::string &frame) {
-    // -01 == pad 3
-    // 0 pad means unknown padding
-    return (std::to_string(std::atoi(frame.c_str())).size() == frame.size() ? 0 : frame.size());
+    // The padding width is always the length of the frame string.
+    // e.g. "0001" -> 4, "1000" -> 4, "-01" -> 3, "" -> 0 (unknown)
+    // Previously, frames with no leading zeros (e.g. "1000") incorrectly
+    // returned 0, producing {:00d} URIs that failed to load any frame.
+    return static_cast<int>(frame.size());
 }
 
 std::string pad_spec(const int pad) {


### PR DESCRIPTION
## Summary

Fixes #152

- `pad_size()` returned `0` when a frame number's natural string representation matched its string length (e.g. `"1000"` → `to_string(1000)` == `"1000"`), indicating "no leading zeros" but incorrectly treating it as unknown/zero padding
- This produced `{:00d}` URIs for sequences like `shot.1000.exr`, causing xSTUDIO to fail loading all frames after the first with `Unsupported file type` warnings
- Fix: the padding width is always the length of the frame string, regardless of leading zeros — simply return `frame.size()`