### PR TITLE
Windows: fix pathFromURL and implement Reveal Source

### DIFF
--- a/include/xstudio/ui/qml/helper_ui.hpp
+++ b/include/xstudio/ui/qml/helper_ui.hpp
@@ -21,6 +21,7 @@ CAF_PUSH_WARNINGS
 #include <QClipboard>
 #include <QCursor>
 #include <QDesktopServices>
+#include <QDir>
 #include <QImage>
 #include <QPixmap>
 #include <QItemSelection>
@@ -508,7 +509,14 @@ class HELPER_QML_EXPORT Helpers : public QObject {
         uris.push_front("-R");
         return startDetachedProcess("open", uris);
 #elif defined(_WIN32)
-        return false;
+        // explorer.exe /select supports only one target per invocation
+        // (unlike macOS `open -R` and Linux ShowItems, which take a list).
+        // Reveal just the first URL.
+        if (urls.isEmpty())
+            return false;
+        QString nativePath = QDir::toNativeSeparators(pathFromURL(urls.first()));
+        QString cmd        = "/select," + nativePath;
+        return startDetachedProcess("explorer.exe", {cmd});
 #else
         auto arguments = QStringList(
             {"--session",
@@ -598,7 +606,18 @@ class HELPER_QML_EXPORT Helpers : public QObject {
 
     Q_INVOKABLE [[nodiscard]] QString pathFromURL(const QUrl &url) const {
 #ifdef _WIN32
-        return url.toString();
+        // xstudio constructs file://localhost//<drive>:/...  which
+        // QUrl::toLocalFile() interprets as a UNC \\localhost\<drive>:\...
+        // path. Drop the localhost authority and the extra leading slash,
+        // then let Qt do the conversion.
+        if (url.host() == QStringLiteral("localhost")) {
+            QUrl u(url);
+            u.setHost(QString());
+            if (u.path().startsWith(QStringLiteral("//")))
+                u.setPath(u.path().mid(1));
+            return u.toLocalFile();
+        }
+        return url.toLocalFile();
 #else
         return url.path().replace("//", "/");
 #endif

--- a/src/plugin/video_output/video_renderer/src/qml/VideoRenderer.1/VideoRendererDialog.qml
+++ b/src/plugin/video_output/video_renderer/src/qml/VideoRenderer.1/VideoRendererDialog.qml
@@ -292,6 +292,8 @@ XsWindow {
             } else if (!with_hashes) {
                 path = ext[1] + "####." + ext[2]
                 outputAudioFile.text = ext[1] + "aiff"
+            } else if (with_hashes) {
+                outputAudioFile.text = ext[1] + "aiff"
             }
         }
         


### PR DESCRIPTION
## Summary

`helpers.pathFromURL` on Windows returned `url.toString()` — the full file URL string with scheme, authority and URL-encoded reserved characters. That string flowed unchanged through every QML caller to user-visible text (window title, clipboard, dialog text fields) and to external process arguments (ffmpeg), producing artefacts like `file:///Z:/path/foo.xst` in the window title and ffmpeg output filenames such as `file:///Z:/foo.%23%23%23%23.%04d.jpg`.

Commit 1 replaces the `pathFromURL` Windows branch with a delegation to `QUrl::toLocalFile()` after patching the one URL shape Qt can't handle on its own (xstudio constructs URLs as `file://localhost//<drive>:/...`, which `toLocalFile()` interprets as a UNC `\\localhost\<drive>:\...` path; the Windows branch strips the localhost authority and collapses the doubled leading slash before delegating). It also implements the previously-empty Windows branch of `showURIS` using `explorer.exe /select`.

Commit 2 adds an explicit branch in `VideoRendererDialog.choose_output` for the case where the user types a filename that already contains `####`. This case was previously masked because Qt URL-encoded the `#` characters and the `with_hashes` regex couldn't detect them; once `pathFromURL` returns a decoded path, the gap surfaces as the audio output filename no longer auto-filling.

## Linux / macOS impact

None. The `pathFromURL` non-Windows branch (`return url.path().replace("//", "/")`) is untouched.