### PR TITLE
Force LF line endings on patch/diff files via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.patch text eol=lf
+*.diff  text eol=lf


### PR DESCRIPTION
## Summary

On Windows the default git config (`core.autocrlf=true`) converts text files to CRLF on checkout. `git apply` — used by the vcpkg overlay-port mechanism — rejects CRLF in diff hunk headers with `corrupt patch at line N`, breaking any vcpkg port that applies a patch as part of its build.

Adding a top-level `.gitattributes` that forces `eol=lf` on `*.patch` and `*.diff` makes those files check out with LF regardless of host autocrlf setting, so `git apply` works on every platform without per-developer git config.

The `* text=auto` line preserves git's normal text-file handling for everything else; only `.patch` and `.diff` get the explicit LF requirement.

## Linux / macOS impact

None.