### PR TITLE
Windows: restore build/install rules dropped by upstream sync

### DIFF
--- a/cmake/macros.cmake
+++ b/cmake/macros.cmake
@@ -207,6 +207,7 @@ macro(default_plugin_options name)
 		add_custom_command(
 				TARGET ${PROJECT_NAME}
 				POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/share/xstudio/plugin"
 				COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${PROJECT_NAME}>" "${CMAKE_BINARY_DIR}/share/xstudio/plugin"
 		)
 	endif()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -63,6 +63,9 @@ if(NOT APPLE)
         if (NOT WIN32)
             install(DIRECTORY ${OUTPUT}/lib/${PYTHONVP}/site-packages/xstudio
                 DESTINATION lib/python/)
+        else()
+            install(DIRECTORY ${OUTPUT}/lib/${PYTHONVP}/site-packages/xstudio
+                DESTINATION bin/python3/Lib/site-packages)
         endif()
 
         if(WIN32)
@@ -83,6 +86,10 @@ if(NOT APPLE)
                 DESTINATION bin)
         endif()
      endif()
+endif()
+
+if(WIN32)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio DESTINATION python FILES_MATCHING PATTERN "*.py")
 endif()
 
 # to run python tests we need xstudio and python.


### PR DESCRIPTION
Two Windows-only build / install fixes.

**`cmake/macros.cmake`** — `default_plugin_options` POST_BUILD copies a plugin DLL to `${CMAKE_BINARY_DIR}/share/xstudio/plugin`. Under parallel builds, `cmake -E copy` creates the destination as a *file* when the path doesn't yet exist as a directory; once that happens, every later `copy_directory` under `share/xstudio/plugin/qml/` fails and the build aborts. Add a `make_directory ${CMAKE_BINARY_DIR}/share/xstudio/plugin` step before the copy.

**`python/CMakeLists.txt`** — add two Windows install rules so the NSIS installer ships the full xstudio Python module:

- `install(DIRECTORY ${OUTPUT}/lib/${PYTHONVP}/site-packages/xstudio DESTINATION bin/python3/Lib/site-packages)` — installs the merged build-tree xstudio package. Without this the installer only bundled `__pybind_xstudio.pyd` in `core/`, missing `__init__.py` and every other submodule.
- `install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/xstudio DESTINATION python FILES_MATCHING PATTERN "*.py")` — installs the source xstudio `.py` tree to `python/xstudio` in the install prefix.

## Linux / macOS impact

None. Both Python install rules are Win32-gated. The `make_directory` step is inside a `WIN32` branch in `default_plugin_options`.