### PR TITLE
Ffprobe fix for FF_PROFILE_UNKNOWN

### DIFF
--- a/src/plugin/media_metadata/ffprobe/src/ffprobe_lib.cpp
+++ b/src/plugin/media_metadata/ffprobe/src/ffprobe_lib.cpp
@@ -447,7 +447,7 @@ nlohmann::json populate_stream(AVFormatContext *avfc, int index, MediaStream *is
     result["profile"] = nullptr;
     if ((profile = avcodec_profile_name(par->codec_id, par->profile)))
         result["profile"] = profile;
-    else if (par->profile != FF_PROFILE_UNKNOWN) {
+    else if (par->profile != AV_PROFILE_UNKNOWN) {
         result["profile"] = std::to_string(par->profile);
     }
 


### PR DESCRIPTION
This is a very simple fix of a ffmpeg attribute that has been renamed from FF_PROFILE_UNKNOWN to AV_PROFILE_UNKNOWN

This is similar to the earlier #196 but rebased to the current devel