### PR TITLE
feat(python): expose annotation read/write API on Bookmark

### DIFF
--- a/python/src/xstudio/api/session/bookmark/bookmark.py
+++ b/python/src/xstudio/api/session/bookmark/bookmark.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
+import json
+
 from xstudio.api.session.container import Container
-from xstudio.core import bookmark_detail_atom, BookmarkDetail
+from xstudio.core import bookmark_detail_atom, BookmarkDetail, add_annotation_atom, serialise_atom, JsonStore
 from xstudio.api.session.media import Media
+
+# This is defined in annotations_core_plugin.hpp 
+ANNOTATIONS_PLUGIN_UUID = "46f386a0-cb9a-4820-8e99-fb53f6c019eb"
+_ANNO_SERIALISER_VERSION = (3 << 8)  # v3.0
 
 
 class Bookmark(Container):
@@ -217,3 +223,71 @@ class Bookmark(Container):
         detail = BookmarkDetail()
         detail.created = x
         self.connection.request_receive(self.remote, bookmark_detail_atom(), detail)
+
+    @property
+    def has_annotation(self):
+        """Whether this bookmark has annotation drawing data.
+
+        Returns:
+            result(bool): True if annotation data exists.
+        """
+        return self.connection.request_receive(self.remote, bookmark_detail_atom())[0].has_annotation
+
+    @property
+    def annotation_data(self):
+        """Raw annotation data as a dict, or None if no annotation exists.
+
+        Reads the annotation from the bookmark's serialised JSON.  This works
+        even without ``add_annotation_atom`` being called, so it is suitable
+        for read-only inspection.
+
+        Returns:
+            result(dict | None): Canvas data under the ``"Data"`` key, or None.
+        """
+        try:
+            raw = self.connection.request_receive(self.remote, serialise_atom())[0]
+            bm = json.loads(raw.dump())
+            return bm.get("base", {}).get("annotation")
+        except Exception:
+            return None
+
+    def set_annotation(self, strokes=None, captions=None, quads=None, polygons=None, ellipses=None):
+        """Set annotation drawing data on this bookmark.
+
+        All geometry uses normalised image-space coordinates (roughly -1..1 on
+        the short axis, Y-up).
+
+        Args:
+            strokes (list[dict] | None): Pen stroke dicts.  Each dict must
+                contain:
+                  - ``"points"`` – flat list [x, y, size_pressure,
+                    opacity_pressure, ...] (size/opacity pressure both 1.0 is
+                    a good default)
+                  - ``"r"``, ``"g"``, ``"b"`` – colour (0.0–1.0)
+                  - ``"opacity"`` (0.0–1.0)
+                  - ``"thickness"`` – line width in image-space units (~0.003–0.02)
+                  - ``"softness"`` (0.0–1.0, default 0.0)
+                  - ``"size_sensitivity"`` (default 1.0)
+                  - ``"opacity_sensitivity"`` (default 1.0)
+                  - ``"is_erase_stroke"`` (bool, default False)
+            captions (list[dict] | None): Text annotation dicts.
+            quads (list[dict] | None): Quad shape dicts.
+            polygons (list[dict] | None): Polygon shape dicts.
+            ellipses (list[dict] | None): Ellipse shape dicts.
+        """
+
+        canvas = {
+            "pen_strokes": strokes or [],
+            "captions": captions or [],
+            "quads": quads or [],
+            "polygons": polygons or [],
+            "ellipses": ellipses or [],
+        }
+        anno_json = {
+            "plugin_uuid": ANNOTATIONS_PLUGIN_UUID,
+            "Annotation Serialiser Version": _ANNO_SERIALISER_VERSION,
+            "Data": canvas,
+        }
+        js = JsonStore()
+        js.parse_string(json.dumps(anno_json))
+        self.connection.request_receive(self.remote, add_annotation_atom(), js)

--- a/src/python_module/src/py_atoms.cpp
+++ b/src/python_module/src/py_atoms.cpp
@@ -370,6 +370,10 @@ void py_config::add_atoms() {
     ADD_ATOM(xstudio::bookmark, associate_bookmark_atom);
     ADD_ATOM(xstudio::bookmark, bookmark_change_atom);
     ADD_ATOM(xstudio::bookmark, render_annotations_atom);
+    ADD_ATOM(xstudio::bookmark, add_annotation_atom);
+    ADD_ATOM(xstudio::bookmark, get_annotation_atom);
+    ADD_ATOM(xstudio::bookmark, annotation_data_atom);
+    ADD_ATOM(xstudio::bookmark, build_annotation_atom);
 
     ADD_ATOM(xstudio::history, undo_atom);
     ADD_ATOM(xstudio::history, redo_atom);


### PR DESCRIPTION
Register get_annotation_atom, annotation_data_atom and build_annotation_atom in py_atoms.cpp. Add three accessors to Bookmark: has_annotation (bool property), annotation_data (read-only serialise-based property returning the canvas dict), and set_annotation() which constructs a JsonStore payload and sends it via add_annotation_atom. Bypasses the AnnotationsCore undo stack intentionally, which is correct for sync/remote-write use cases.


(cherry picked from commit 964d1e294374b0bed9df8881b3a205b16513100b)

<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit!

### Pull Request TITLE

It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues
<!--
Link the Issue(s) this Pull Request is related to.

Each PR should link to at least one issue, in the form:

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Fixes #12345
Fixes #54345
-->

### Summarize your change.

### Describe the reason for the change.

### Describe what you have tested and on which operating system.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.