### PR TITLE
Filesystem add fixes

### DIFF
--- a/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
+++ b/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
@@ -159,7 +159,7 @@ class XStudioHostInterface:
         except Exception:
             target_playlist = None
         if not target_playlist:
-            target_playlist = self.connection.api.session.create_playlist("File System Imports")
+            _, target_playlist = self.connection.api.session.create_playlist("File System Imports")
 
         try:
             is_timeline = target_playlist.type == "Timeline"

--- a/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
+++ b/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
@@ -154,10 +154,13 @@ class XStudioHostInterface:
         Args:
             path (str): The path to the file or sequence to load.
         """
-        target_playlist = self.connection.api.session.inspected_container
+        try:
+            target_playlist = self.connection.api.session.inspected_container
+        except Exception:
+            target_playlist = None
         if not target_playlist:
             target_playlist = self.connection.api.session.create_playlist("File System Imports")
-            
+
         for m in target_playlist.media:
             try:
                 if m.metadata.get("/fs_browser/import_path") == path:

--- a/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
+++ b/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
@@ -177,7 +177,7 @@ class XStudioHostInterface:
 
         self.connection.api.session.viewed_container = target_playlist
         target_playlist.playhead_selection.set_selection([media.uuid])
-        playlist.playhead.playing = True
+        target_playlist.playhead.playing = True
 
     def replace_current_media(self, path):
         """

--- a/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
+++ b/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
@@ -161,6 +161,11 @@ class XStudioHostInterface:
         if not target_playlist:
             target_playlist = self.connection.api.session.create_playlist("File System Imports")
 
+        try:
+            is_timeline = target_playlist.type == "Timeline"
+        except Exception:
+            is_timeline = False
+
         for m in target_playlist.media:
             try:
                 if m.metadata.get("/fs_browser/import_path") == path:
@@ -169,11 +174,13 @@ class XStudioHostInterface:
             except:
                 pass
 
-        seq_path = self._format_sequence_path(path) if fileseq_available else None
-        if seq_path:
-            media = target_playlist.add_media(seq_path)
+        add_path = (self._format_sequence_path(path) if fileseq_available else None) or path
+
+        if is_timeline:
+            media = target_playlist.parent_playlist.add_media(add_path)
+            target_playlist.add_media(media)
         else:
-            media = target_playlist.add_media(path)
+            media = target_playlist.add_media(add_path)
 
         self.connection.api.session.viewed_container = target_playlist
         target_playlist.playhead_selection.set_selection([media.uuid])


### PR DESCRIPTION

### Pull Request Filesystem browser add to playlist errors.

The filesystem browser was erroring out if:
* A playlist didnt exist (it didnt create one) - it now does.
* If you were adding to a Sequence rather than a playlist.
* There was a typo in one of those cases since a variable was undefined.
