### PR TITLE
Fix .webm files failing to load via CLI argument

### DIFF
--- a/src/utility/src/sequence.cpp
+++ b/src/utility/src/sequence.cpp
@@ -363,7 +363,7 @@ std::string escape_percentage(const std::string &str) {
 static const std::set<std::string> not_sequence_ext_set{
     ".BZ2", ".bz2", ".MOV", ".mov", ".AVI", ".avi",  ".CINE", ".cine", ".R3D", ".r3d", ".AAF",
     ".aaf", ".MXF", ".mxf", ".WAV", ".wav", ".AIFF", ".aiff", ".AIF", ".aif", ".HIP",  ".hip", ".MB",  ".mb",
-    ".MA",  ".ma",  ".NK",  ".nk",  ".mv4", ".MP4",  ".mp4",  ".mp3",  ".MP3", ".WEBM"};
+    ".MA",  ".ma",  ".NK",  ".nk",  ".mv4", ".MP4",  ".mp4",  ".mp3",  ".MP3", ".WEBM", ".webm"};
 
 bool default_is_sequence(const Entry &entry) {
     // things that are never sequences..


### PR DESCRIPTION
Add it to not_sequence_ext_set. Maya writes lowercase .webm files.