### PR TITLE
Fix session reuse on Windows and macOS

### DIFF
--- a/src/launch/xstudio/src/xstudio.cpp
+++ b/src/launch/xstudio/src/xstudio.cpp
@@ -1093,13 +1093,13 @@ struct Launcher {
                         auto remote = request_receive_wait<caf::actor>(
                             *self,
                             connecting,
-                            std::chrono::seconds(2),
+                            std::chrono::seconds(3),
                             caf::connect_atom_v,
                             host,
                             port);
 
                         auto auth = request_receive_wait<caf::actor>(
-                            *self, remote, std::chrono::seconds(2), authenticate_atom_v);
+                            *self, remote, std::chrono::seconds(3), authenticate_atom_v);
 
                         spdlog::info("Connected to session '{}' at {}:{}", name, host, port);
                         return auth;

--- a/src/utility/src/remote_session_file.cpp
+++ b/src/utility/src/remote_session_file.cpp
@@ -6,6 +6,13 @@
 #include <limits>
 #include <regex>
 
+#ifdef _WIN32
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <csignal>
+#include <cerrno>
+#endif
+
 #include "xstudio/utility/helpers.hpp"
 #include "xstudio/utility/logging.hpp"
 #include "xstudio/utility/remote_session_file.hpp"
@@ -44,7 +51,21 @@ RemoteSessionFile::RemoteSessionFile(const std::string &file_path) {
 
     // test pid if host is local.
     if (host_ == "localhost" and pid_) {
-        if (not exists(fs::path(fmt::format("/proc/{}", pid_)))) {
+        bool alive = false;
+#ifdef _WIN32
+        HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid_);
+        if (h) {
+            DWORD exit_code = 0;
+            alive = GetExitCodeProcess(h, &exit_code) && exit_code == STILL_ACTIVE;
+            CloseHandle(h);
+        }
+#elif defined(__APPLE__)
+        // POSIX signal 0 doesn't deliver a signal, just checks existence.
+        alive = (kill(pid_, 0) == 0) || (errno == EPERM);
+#else
+        alive = exists(fs::path(fmt::format("/proc/{}", pid_)));
+#endif
+        if (not alive) {
             remove(filepath());
             throw std::runtime_error("Invalid remote session file, process dead. " + file_name);
         }


### PR DESCRIPTION
Two things made xstudio launch a new instance on second launch
instead of reconnecting:

- /proc/<pid> liveness check is Linux-only; on Windows and macOS
  every session file was treated as dead. Use OpenProcess on Windows
  and kill(pid, 0) on macOS.
- The 2s connect timeout on Windows was still too tight after that;
  BASP loopback handshake takes ~2030 ms on my test systems. Bumped
  to 3s, I hope an extra second is ok.