### PR TITLE
Filesystem Browser fixes

### DIFF
--- a/python/src/xstudio/api/session/playlist/playlist.py
+++ b/python/src/xstudio/api/session/playlist/playlist.py
@@ -20,6 +20,7 @@ from xstudio.api.auxiliary import NotificationHandler
 from xstudio.api.auxiliary.json_store import JsonStoreHandler
 
 import json
+from pathlib import Path
 
 class Playlist(Container, NotificationHandler, JsonStoreHandler):
     """Playlist object."""
@@ -127,12 +128,13 @@ class Playlist(Container, NotificationHandler, JsonStoreHandler):
             result = self.connection.request_receive(self.remote, add_media_atom(), path, False, Uuid())[0]
         else:
             ppp = parse_posix_path(path)
+            name = Path(path).name.split(".", 1)[0] # this is to match what happens internally with a URI above
 
             if not str(ppp[1]) and frame_list is None:
-                result = self.connection.request_receive(self.remote, add_media_atom(), path, ppp[0], Uuid())[0]
+                result = self.connection.request_receive(self.remote, add_media_atom(), name, ppp[0], Uuid())[0]
             else:
                 result = self.connection.request_receive(
-                    self.remote, add_media_atom(), path, ppp[0], ppp[1] if frame_list is None else frame_list, Uuid()
+                    self.remote, add_media_atom(), name, ppp[0], ppp[1] if frame_list is None else frame_list, Uuid()
                 )[0]
 
         return Media(self.connection, result.actor, result.uuid)

--- a/src/plugin/python_plugins/filesystem_browser/config.json
+++ b/src/plugin/python_plugins/filesystem_browser/config.json
@@ -3,6 +3,7 @@
         ".mov",
         ".mp4",
         ".mkv",
+        ".mxf",
         ".exr",
         ".jpg",
         ".jpeg",

--- a/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
+++ b/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
@@ -122,6 +122,7 @@ class XStudioHostInterface:
             seq_path = self._format_sequence_path(path)
             return playlist.add_media(seq_path if seq_path else path)
         except Exception as e:
+            import traceback
             _dbg (traceback.format_exc())
             _dbg(f"Add media error: {e}")
             return None

--- a/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
+++ b/src/plugin/python_plugins/filesystem_browser/filesystem_browser.py
@@ -3,6 +3,7 @@
 
 from xstudio.plugin import PluginBase
 from xstudio.core import JsonStore, FrameList, add_media_atom, Uuid
+from xstudio.core import KeyboardModifier
 import os
 from enum import Enum
 import sys
@@ -160,6 +161,8 @@ class XStudioHostInterface:
             target_playlist = None
         if not target_playlist:
             _, target_playlist = self.connection.api.session.create_playlist("File System Imports")
+            self.connection.api.session.inspected_container = target_playlist
+            
 
         try:
             is_timeline = target_playlist.type == "Timeline"
@@ -328,39 +331,15 @@ class FilesystemBrowserPlugin(PluginBase):
         )
         self.command_attr.expose_in_ui_attrs_group("Filesystem Browser")
         
-        # Action to toggle the panel
-        self.toggle_action_uuid = "2669e4a3-7186-4556-9818-80949437b018"
-        
         self.toggle_browser_action = self.register_hotkey(
             self.toggle_browser, # hotkey_callback
             "B", # default_keycode
-            0, # default_modifier
+            KeyboardModifier.MetaModifier,
             "Show Filesystem Browser",
             "Toggles the Filesystem Browser panel",
             False, # auto_repeat
             "FilesystemBrowser", # component
             "Window" # context
-        )
-        
-        # Menu item triggers this action
-        # Removed manual callback to rely on hotkey_uuid linkage 
-        # which should toggle the panel automatically if registered correctly.
-        self.insert_menu_item(
-            "main menu bar",
-            "Filesystem Browser",
-            "View|Panels",
-            0.0,
-            hotkey_uuid=self.toggle_browser_action,
-            callback=self.toggle_browser_from_menu
-        )
-
-        # Add menu item to open as floating window
-        self.insert_menu_item(
-            "main menu bar",
-            "Browser Open",
-            "Plugins",
-            0.1,
-            callback=self.open_floating_browser
         )
         
         # Register the panel, passing the action
@@ -372,8 +351,8 @@ class FilesystemBrowserPlugin(PluginBase):
             }
             """,
             10.0, # Position in menu
-            "", # No icon = Standard Panel (Docked)
-            -1.0,
+            "qrc:/icons/folder.svg", # No icon = Standard Panel (Docked)
+            5.0,
             self.toggle_browser_action # Pass the action UUID
         )
         
@@ -640,33 +619,6 @@ class FilesystemBrowserPlugin(PluginBase):
         if not val: return set()
         return set(item.strip() for item in val.split(',') if item.strip())
         
-    def toggle_browser_from_menu(self, menu_item=None, user_data=None):
-        # Wrapper for menu callback
-        # Since we are now a standard dockable panel, the user should use View -> Panels -> Filesystem Browser
-        # or rely on the hotkey's default action if it maps to the view.
-        # We'll just log here.
-        _dbg("Menu item clicked. The Filesystem Browser is available in the Panels menu.")
-        self.toggle_browser(None, "Menu Click")
-
-    def open_floating_browser(self):
-        # Create a floating window containing the FilesystemBrowser component
-        qml = """
-        import QtQuick.Window 2.15
-        import QtQuick.Controls 2.15
-        
-        Window {
-            width: 900
-            height: 600
-            visible: true
-            title: "Filesystem Browser"
-            
-            FilesystemBrowser {
-                anchors.fill: parent
-            }
-        }
-        """
-        self.create_qml_item(qml)
-
     def toggle_browser(self, converting, context):
         _dbg(f"Toggling Filesystem Browser (Action Triggered). Context: {context}")
         # We can also verify visibility here if possible, but the Model handles it.

--- a/src/plugin/python_plugins/filesystem_browser/qml/FilesystemBrowserXStudio.1/FilesystemBrowser.qml
+++ b/src/plugin/python_plugins/filesystem_browser/qml/FilesystemBrowserXStudio.1/FilesystemBrowser.qml
@@ -29,7 +29,6 @@ Item {
     property var selectedItemsUrls: []
     property var selectedItemsPaths: []
     property var underMouseIndex: -1
-    property var dragVisItem: undefined
 
     onSelectedItemsChanged: {        
         var v = []
@@ -85,24 +84,14 @@ Item {
 
             if (!selectedItems.includes(index)) {
                 selectedItems = [index]
-            }
-            if (selectedItems.length == 1) {
+
                 var item = viewMode === 3 ? flatThumbnailModel[index] : visibleTreeList[index]
-                if (!item.data.is_folder) {
+                if (item.type != "header" && !item.data.is_folder) {
                     pendingPreviewPath = item.path
                     previewTimer.restart()
                 }
             }
         }
-
-    }
-
-    XsDragDropHandler {
-
-        id: drag_drop_handler
-        dragSourceName: "External URIS"
-        dragData: root.selectedItemsUrls
-
     }
 
     XsGradientRectangle{
@@ -315,6 +304,7 @@ Item {
         onValueChanged: {
             currentFilterTime = value || "Any"
             refreshFiltering()
+            sendCommand({"action": "change_path", "path": current_path_attr.value});
         }
         Component.onCompleted: {
              currentFilterTime = value || "Any"
@@ -328,6 +318,7 @@ Item {
         onValueChanged: {
              currentFilterVersion = value || "All Versions"
              refreshFiltering()
+             sendCommand({"action": "change_path", "path": current_path_attr.value});
         }
         Component.onCompleted: {
              currentFilterVersion = value || "All Versions"
@@ -956,31 +947,29 @@ Item {
                     propagateComposedEvents: true
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
                     hoverEnabled: true
-                
-                    onPositionChanged: (mouse)=> {
-                        if (pressed && mouse.buttons == Qt.LeftButton) {
-                            var pt = mapToItem(root, mouse.x, mouse.y)
-                            drag_drop_handler.doDrag(pt.x, pt.y)
-                        }
-                    }
-                
-                    onReleased: (mouse)=> {
-                        if (underMouseIndex != -1 && mouse.button === Qt.LeftButton && mouse.modifiers == Qt.NoModifier && !drag_drop_handler.dragging) {    
-                            selectedItems = []
-                            selectItem(underMouseIndex, 0)
-                        } else {
-                            var pt = mapToItem(root, mouse.x, mouse.y)
-                            drag_drop_handler.endDrag(pt.x, pt.y)
-                        }
-                    }
 
                     onPressed: (mouse) => {
-                        if (underMouseIndex != -1) {
-                            dragVisItem = fileListView.visible ? fileListView.itemAtIndex(underMouseIndex) : thumbFlickable.thumbs.itemAt(underMouseIndex)
-                        }
-                        drag_drop_handler.startDrag(mouseX, mouseY, dragVisItem)
-                        if (underMouseIndex != -1 && mouse.button === Qt.LeftButton) {
-                            selectItem(underMouseIndex, mouse.modifiers == Qt.ShiftModifier ? 1 : mouse.modifiers == Qt.ControlModifier ? 2 : 0)
+                        if (mouse.button === Qt.LeftButton) {
+                            if (underMouseIndex != -1) {
+                                selectItem(underMouseIndex, mouse.modifiers == Qt.ShiftModifier ? 1 : mouse.modifiers == Qt.ControlModifier ? 2 : 0)
+                            } else {
+                                previewTimer.stop()
+                                isPreviewMode = false
+                                sendCommand({"action": "preview_file", "path": ""})
+                                selectedItems = []
+                            }
+                        } else if (mouse.button === Qt.RightButton) {
+                            if (underMouseIndex != -1) {
+                                if (!selectedItems.includes(underMouseIndex))
+                                    selectItem(underMouseIndex, 0)
+
+                                let clickedItemPath = root.viewMode === 3 ? flatThumbnailModel[underMouseIndex].path : visibleTreeList[underMouseIndex].path
+                                thumbContextMenu.selectedPaths = root.selectedItemsPaths
+                                thumbContextMenu.itemPath = clickedItemPath
+                                thumbContextMenu.showMenu(
+                                    mouseArea,
+                                    mouse.x, mouse.y);
+                            }
                         }
                     }
 
@@ -994,21 +983,35 @@ Item {
                     }
 
                     onClicked: (mouse) => {
-                        if (mouse.button === Qt.RightButton && underMouseIndex != -1) {
-                            let clickedItemPath = root.viewMode === 3 ? flatThumbnailModel[underMouseIndex].path : visibleTreeList[underMouseIndex].path
-                            thumbContextMenu.selectedPaths = root.selectedItemsPaths
-                            thumbContextMenu.itemPath = clickedItemPath
-                            thumbContextMenu.showMenu(
-                                mouseArea,
-                                mouse.x, mouse.y);
+                        if (mouse.button === Qt.LeftButton && mouse.modifiers == Qt.NoModifier && underMouseIndex != -1) {
+                            selectedItems = []
+                            selectItem(underMouseIndex, 0)
                         }
                     }
-                
+
+                    DragHandler {
+                        id: dragHandler
+                        target: null
+
+                        onActiveChanged: {
+                            if (active && underMouseIndex != -1) {
+                                previewTimer.stop()
+                                isPreviewMode = false
+                                dragProxy.grabToImage(function(result) {
+                                    let d = root.selectedItemsPaths.map(p => encodeURIComponent(p))
+                                    dragProxy.Drag.mimeData = {"text/plain": d.join("\n")}
+                                    dragProxy.Drag.imageSource = result.url
+                                    dragProxy.Drag.active = true
+                                })
+                            } else {
+                                dragProxy.Drag.active = false
+                            }
+                        }
+                    }                                
+                                
                     FSFileContextMenu {
                         id: thumbContextMenu
                     }
-                        
-                    
                 }
 
                 // Nothing found message
@@ -1066,6 +1069,52 @@ Item {
 
         }
     }
+
+    Item {
+        id: dragProxy
+        property var dragItem: underMouseIndex === -1 ? null : (
+            root.viewMode === 3 ? thumbFlickable.thumbs.itemAt(underMouseIndex) : fileListView.itemAtIndex(underMouseIndex))
+        property int dragCount: selectedItems.length
+
+        width: dragItem ? Math.min(dragItem.width, 300) : 0
+        height: dragItem ? Math.max(dragItem.height, 64) : 0
+        visible: false
+        z: 100
+
+        Drag.dragType: Drag.Automatic
+        Drag.supportedActions: Qt.CopyAction
+        Drag.hotSpot.x: width/2
+        Drag.hotSpot.y: height/2
+
+        ShaderEffectSource {
+            width: parent.width
+            height: parent.height
+            sourceRect.width: width
+            sourceRect.height: height
+            sourceItem: parent.dragItem
+            opacity: 0.65
+        }
+
+        // Count badge
+        Rectangle {
+            x: parent.width / 2 + 20
+            y: parent.height / 2 - 20
+            width: dragProxy.dragCount > 1 ? 22 : 0
+            height: 22
+            radius: 11
+            color: "#e05a00"
+            clip: true
+
+            Text {
+                anchors.centerIn: parent
+                text: dragProxy.dragCount
+                color: "#ffffff"
+                font.pixelSize: 10; font.weight: Font.Bold
+            }
+        }
+    }
+
+    property alias dragProxy: dragProxy
 
     property alias thumbToolTip: thumbToolTip
     XsToolTip {

--- a/src/plugin/python_plugins/filesystem_browser/qml/FilesystemBrowserXStudio.1/styled_widgets/FSMainHeader.qml
+++ b/src/plugin/python_plugins/filesystem_browser/qml/FilesystemBrowserXStudio.1/styled_widgets/FSMainHeader.qml
@@ -40,6 +40,7 @@ Rectangle {
             onTextChanged: {
                 filterField = text
                 refreshFiltering()
+                sendCommand({"action": "change_path", "path": current_path_attr.value});
             }
             hint: "Filter String..."
         }

--- a/src/plugin/python_plugins/filesystem_browser/qml/FilesystemBrowserXStudio.1/styled_widgets/FSPathInput.qml
+++ b/src/plugin/python_plugins/filesystem_browser/qml/FilesystemBrowserXStudio.1/styled_widgets/FSPathInput.qml
@@ -97,8 +97,15 @@ RowLayout {
         }
 
         TapHandler {
-            acceptedButtons: Qt.RightButton
-            onTapped: (eventPoint) => pathContextMenu.showMenu(parent, eventPoint.position.x, eventPoint.position.y)
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            onTapped: (eventPoint, button) => {
+                if (button == Qt.RightButton) {
+                    pathContextMenu.showMenu(parent, eventPoint.position.x, eventPoint.position.y)
+                } else if (tapCount == 3) {
+                    // Make sure the path field retains focus when triple clicking.
+                    pathField.forceActiveFocus()
+                }
+            }
         }
 
         XsPopupMenu {
@@ -270,6 +277,7 @@ RowLayout {
     
     XsPrimaryButton {
 
+        id: historyBtn
         Layout.preferredHeight: XsStyleSheet.primaryButtonStdHeight
         Layout.preferredWidth: 32
         


### PR DESCRIPTION
This PR fixes a few big issues and adds a couple of small improvements to the Filesystem Browser. Here is the complete rundown...

Added ".mxf" as a media file extension.

Changed the Filesystem Browser hotkey from "B" to "Meta+B" as it was clashing with the the existing "B" hotkey to view the blue channel.

When no playlist exists, a "File System Import" playlist was being created and viewed, but not inspected. Added a change to also make it the inspected playlist.

Reworked the UI instantiation logic to leverage the built-in xstudio panel API. This fixed the broken hotkey, which required adding a button to the action bar as well.

Removed the "Plugins|Browser Open" menu as the new action bar button does the same thing.

Removed the "View|Panels" menu as it just wasn't working and it was redundant.

Reworked the drag-and-drop to allow it to work from the pop-out window version of the browser the same way it works from the embedded panel version. Previously it just didn't work in the pop-out window.

Modified the preview logic to prevent from being triggered excessively.

Changing any of the filter settings causes a refresh of the current path. This provides both immediate results for any media directly within the current path, and also resets the deep-scan so it can be manually triggered again. Previously there was no easy way to force a refresh when changing the filter settings (that I could see).

Fixed a couple of error messages.

Fixed a focus issue when triple-clicking in the path field to select the whole text.
