### PR TITLE
Fix ffprobe plugin returning empty result for webm/mkv

### DIFF
--- a/src/plugin/media_metadata/ffprobe/src/ffprobe_lib.cpp
+++ b/src/plugin/media_metadata/ffprobe/src/ffprobe_lib.cpp
@@ -775,11 +775,6 @@ std::shared_ptr<MediaFile> FFProbe::open_file(const std::string &path) {
         if (scan_all_pmts_set)
             av_dict_set(&format_opts, "scan_all_pmts", nullptr, AV_DICT_MATCH_CASE);
 
-        // what is this even doing ?
-        if ((t = av_dict_get(format_opts, "", nullptr, AV_DICT_IGNORE_SUFFIX))) {
-            throw std::runtime_error("Option scan_all_pmts not found.");
-        }
-
         {
             AVDictionary **opts  = init_find_stream_opts(result->fmt_ctx, codec_opts);
             auto orig_nb_streams = result->fmt_ctx->nb_streams;


### PR DESCRIPTION
The leftover-options check after `avformat_find_stream_info` throws if any option is left in the dict. mov/mp4 stay quiet because the mov demuxer consumes the `export_all=1` seed; matroska/webm doesn't know that option, leaves it behind, the throw fires, and `probe_file` returns `{}` — so webm media shows no codec, resolution, etc. in the media view. The stale error string ("Option scan_all_pmts not found") doesn't even describe what's actually being detected. Drop the check — fftools/ffprobe.c only used the equivalent loop to log a per-option CLI warning, not as a hard error.