### PR TITLE
Fix HTTP source playback on Windows

### DIFF
--- a/src/utility/src/helpers.cpp
+++ b/src/utility/src/helpers.cpp
@@ -666,7 +666,8 @@ xstudio::utility::scan_posix_path(const std::string &path, const int depth) {
     fs::path p(path);
 
     try {
-        if (fs::is_directory(p)) {
+        std::error_code ec;
+        if (fs::is_directory(p, ec)) {
             // read content.
             try {
                 std::vector<std::string> files;
@@ -699,7 +700,7 @@ xstudio::utility::scan_posix_path(const std::string &path, const int depth) {
             } catch (const std::exception &e) {
                 spdlog::warn("{} {}", __PRETTY_FUNCTION__, e.what());
             }
-        } else if (fs::is_regular_file(p)) {
+        } else if (fs::is_regular_file(p, ec)) {
             items.emplace_back(std::make_pair(posix_path_to_uri(path), FrameList()));
         } else {
 


### PR DESCRIPTION
`scan_posix_path` already has an http handler in its trailing else branch, but on Windows it was unreachable: `fs::is_directory("http://…")` throws `std::filesystem_error` ("The specified path is invalid"), the outer catch swallows it, and the function returns `{}` — the caller sees no media. Linux's POSIX `stat()` returns `ENOENT` instead, so the throwing overload returns false and execution falls through to the http handler. That's why the bug never showed up there.

Switch both `fs::is_directory` and `fs::is_regular_file` to the `(path, error_code)` overloads. They do the same syscall but report errors through `error_code` instead of throwing, so on Windows they return false for a URL string and the http handler is reached, matching Linux. Safe on Linux because the new overloads share their implementation with the throwing form.