### PR TITLE
Fix Intel "Failed to map buffer for frame" during playback

### DIFF
--- a/src/ui/opengl/src/opengl_rgba8bit_image_texture.cpp
+++ b/src/ui/opengl/src/opengl_rgba8bit_image_texture.cpp
@@ -43,13 +43,13 @@ bool GLBlindRGBA8bitTex::resize(const size_t required_size_bytes) {
             return false;
         }
 
-#ifdef __OPENGL_4_1__
         if (mapped_address_) {
+#ifdef __OPENGL_4_1__
             glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pixel_buf_object_id_);
             glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+#endif
             mapped_address_ = nullptr;
         }
-#endif
 
         glDeleteTextures(1, &tex_id_);
         glDeleteBuffers(1, &pixel_buf_object_id_);
@@ -133,7 +133,8 @@ uint8_t *GLBlindRGBA8bitTex::map_buffer_for_upload(const size_t buffer_size) {
         tex_width_ * tex_height_ * bytes_per_pixel_,
         nullptr,
         GL_DYNAMIC_DRAW);
-    return (uint8_t *)glMapNamedBuffer(pixel_buf_object_id_, GL_WRITE_ONLY);
+    mapped_address_ = (uint8_t *)glMapNamedBuffer(pixel_buf_object_id_, GL_WRITE_ONLY);
+    return mapped_address_;
 #endif
 }
 
@@ -150,10 +151,10 @@ void GLBlindRGBA8bitTex::__bind(int tex_index, Imath::V2i &dims) {
 
         // now the texture data is transferred (on the GPU).
         // Assumption is that this is fast.
+        mapped_address_ = nullptr;
 #ifdef __OPENGL_4_1__
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pixel_buf_object_id_);
         bool r          = glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
-        mapped_address_ = nullptr;
 #else
         glUnmapNamedBuffer(pixel_buf_object_id_);
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pixel_buf_object_id_);


### PR DESCRIPTION
The Mac (`__OPENGL_4_1__`) path of `GLBlindRGBA8bitTex::map_buffer_for_upload` stores the `glMapBuffer` result in `mapped_address_`, so the cache check at the top short-circuits subsequent calls. The non-Mac path returned `glMapNamedBuffer` directly without storing it, so the cache never fired and every prepare-for-upload re-ran `glNamedBufferData` + `glMapNamedBuffer` on the same PBO.

NVIDIA accepts the re-orphan-and-map; Intel returns NULL once the buffer has been used as a `GL_PIXEL_UNPACK_BUFFER` source, which spams "Failed to map buffer for frame" during normal playback. Store the map result, clear it after `glUnmapNamedBuffer` in `__bind`, and after buffer deletion in `resize()` so we don't return a stale pointer.

Tested on Windows with both Intel and NVIDIA GPUs, and on Linux with NVIDIA. If it's really necessary to test the Linux/Intel combination I can do it, but it won't be until next week.