### PR TITLE
Flag colour hotkeys and code consolidation

### DIFF
--- a/python/src/xstudio/api/session/playlist/timeline/item.py
+++ b/python/src/xstudio/api/session/playlist/timeline/item.py
@@ -125,16 +125,9 @@ class Item(Container):
         """
         colour = self.item.flag()
 
-        colours = {
-            "#FFFF0000": "Red",
-            "#FF00FF00": "Green",
-            "#FF0000FF": "Blue",
-            "#FFFFFF00": "Yellow",
-            "#FFFFA500": "Orange",
-            "#FF800080": "Purple",
-            "#FF000000": "Black",
-            "#FFFFFFFF": "White",
-        }
+        colours = {d["colour"]: d["name"] for d in
+                   self.connection.api.global_store
+                   .value("/core/session/media_flags").get()}
 
         return colours[colour] if colour in colours else colour
 

--- a/ui/qml/xstudio/application/XsSessionWindow.qml
+++ b/ui/qml/xstudio/application/XsSessionWindow.qml
@@ -410,6 +410,12 @@ ApplicationWindow {
     }
     property alias file_functions: file_functions
 
+    XsPreference {
+        id: __media_flags
+        path: "/core/session/media_flags"
+    }
+    property alias flagColours: __media_flags.value
+
     ColumnLayout {
 
         anchors.fill: parent

--- a/ui/qml/xstudio/application/panels/media/functions/XsMediaListFunctions.qml
+++ b/ui/qml/xstudio/application/panels/media/functions/XsMediaListFunctions.qml
@@ -328,20 +328,16 @@ Item {
         )
     }
 
+    function setColour(indexes, idx) {
+        indexes.forEach(
+            function (item, index) {
+                theSessionData.set(item, flagColours[idx].colour, "flagColourRole")
+            }
+        )
+    }
 
     function cycleColour(indexes) {
-        let colours = [
-            "#FFFF0000",
-            "#FF00FF00",
-            "#FF0000FF",
-            "#FFFFFF00",
-            "#FFFFA500",
-            "#FF800080",
-            "#FF000000",
-            "#FFFFFFFF",
-            "#00000000",
-        ]
-
+        var colours = flagColours.map(obj => Object.values(obj)[0])
         indexes.forEach(
             function (item, index) {
                 let current = theSessionData.get(item, "flagColourRole")

--- a/ui/qml/xstudio/application/panels/media/widgets/XsMediaHotKeys.qml
+++ b/ui/qml/xstudio/application/panels/media/widgets/XsMediaHotKeys.qml
@@ -312,4 +312,19 @@ XsHotkeyArea {
         onActivated: theSessionData.rescanMedia(mediaSelectionModel.selectedIndexes)
         componentName: "Media List"
     }
+
+    // add hotkeys for setting flag colours
+    Repeater {
+        model: flagColours.length
+        Item {
+            XsHotkey {
+                sequence: "Ctrl+Alt+" + index
+                name: "Set flag #" + index + ": " + flagColours[index].name
+                description: "Set flag #" + index + ": " + flagColours[index].name
+                context: hotkey_area.context
+                onActivated: media_list_functions.setColour(mediaSelectionModel.selectedIndexes, index)
+                componentName: "Media List"
+            }
+        }
+    }
 }

--- a/ui/qml/xstudio/application/panels/timeline/XsTimeline.qml
+++ b/ui/qml/xstudio/application/panels/timeline/XsTimeline.qml
@@ -983,17 +983,8 @@ Rectangle {
         onActivated: {
             let clipIndex = theSessionData.getTimelineClipIndex(timeline_items.rootIndex, timelinePlayhead.logicalFrame);
             if(clipIndex.valid) {
-                let colours = [
-                    "#FFFF0000",
-                    "#FF00FF00",
-                    "#FF0000FF",
-                    "#FFFFFF00",
-                    "#FFFFA500",
-                    "#FF800080",
-                    "#FF000000",
-                    "#FFFFFFFF",
-                    "",
-                ]
+                let colours = flagColours.map(obj => Object.values(obj)[0])
+                colours[0] = ""
                 let current = theSessionData.get(clipIndex, "flagColourRole")
                 let cind = colours.indexOf(current)
                 if(cind == -1 || cind == colours.length-1)

--- a/ui/qml/xstudio/menus/XsFlagMenuInserter.qml
+++ b/ui/qml/xstudio/menus/XsFlagMenuInserter.qml
@@ -11,50 +11,9 @@ Item {
 
     id: flag_menu_inserter
 
-    property string text: "Flag Media"
+    property string text: "Flag Selected Media"
 
     signal flagSet(string flag, string flag_text)
-
-    ListModel {
-        id: colours_model
-
-        ListElement {
-            name: "Remove Flag"
-            colour: "#00000000"
-        }
-        ListElement {
-            name: "Red"
-            colour: "#FFFF0000"
-        }
-        ListElement {
-            name: "Green"
-            colour: "#FF00FF00"
-        }
-        ListElement {
-            name: "Blue"
-            colour: "#FF0000FF"
-        }
-        ListElement {
-            name: "Yellow"
-            colour: "#FFFFFF00"
-        }
-        ListElement {
-            name: "Orange"
-            colour: "#FFFFA500"
-        }
-        ListElement {
-            name: "Purple"
-            colour: "#FF800080"
-        }
-        ListElement {
-            name: "Black"
-            colour: "#FF000000"
-        }
-        ListElement {
-            name: "White"
-            colour: "#FFFFFFFF"
-        }
-    }
 
     property var menuModelName
     property var panelContext: null
@@ -77,18 +36,18 @@ Item {
 
     Repeater {
         id: repeater
-        model: colours_model
+        model: flagColours
         Item {
             XsMenuModelItem {
                 id: menu_item
-                text: name
+                text: modelData.name
                 menuItemType: "custom"
                 menuPath: fullMenuPath
                 menuItemPosition: index
                 menuModelName: flag_menu_inserter.menuModelName
-                userData: colour
+                userData: modelData.colour
                 onActivated: {
-                    flagSet(colour, name != "Remove Flag" ? name : "")
+                    flagSet(modelData.colour, modelData.name != "Remove Flag" ? modelData.name : "")
                 }
                 panelContext: flag_menu_inserter.panelContext
                 customMenuQml: "import xStudio 1.0; XsFlagMenuItem {}"

--- a/ui/qml/xstudio/menus/XsFlagMenuItem.qml
+++ b/ui/qml/xstudio/menus/XsFlagMenuItem.qml
@@ -66,7 +66,7 @@ Item {
             width: XsStyleSheet.menuCheckboxSize
             height: XsStyleSheet.menuCheckboxSize
             radius: width/2
-            color: user_data
+            color: user_data || "transparent"
 
         }
 


### PR DESCRIPTION
This consolidates the configuration of the colours available in colour selection menus. Previously the list of available colours was hard-coded in multiple locations. Now the list of colours are all taken from the "/core/session/media_flags" preference which already exists but was unused.

Additionally, this adds hotkeys for directly setting the flag colour on selected media items in the media panel. The hotkeys are Ctrl+Alt+<number>.

This has been tested under both MacOS and Linux (ubuntu-22.04).