### PR TITLE
Annotation workflow improvements.

### DIFF
--- a/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.cpp
+++ b/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.cpp
@@ -1298,11 +1298,32 @@ void AnnotationsCore::make_bookmark_for_annotations(
 
     bookmark::BookmarkDetail detail;
     detail.uuid_ = bm_id;
-    std::string note_name =
-        fs::path(utility::uri_to_posix_path(frame_id.uri())).stem().string();
-    if (note_name.find(".") != std::string::npos) {
-        note_name = std::string(note_name, 0, note_name.find("."));
+
+    caf::scoped_actor sys{system()};
+    std::string media_name;
+    std::string media_path;
+
+    try {
+        media_name = request_receive<std::string>(
+            *sys, frame_id.media_actor(), utility::name_atom_v);
+        media_path = utility::uri_to_posix_path(frame_id.uri());
+    } catch (...) {
+        // pass
     }
+
+    // If the media actor's name is not empty and is different from the media's
+    // path then assume it should be used for the name of the annotation's note.
+    // Otherwise extract the first portion of the path's filename.
+    std::string note_name;
+    if (! media_name.empty() && media_name != media_path) {
+        note_name = media_name;
+    } else {
+        note_name = fs::path(media_path).stem().string();
+        if (note_name.find(".") != std::string::npos) {
+            note_name = std::string(note_name, 0, note_name.find("."));
+        }
+    }
+
     detail.category_ = note_category_->value();
     detail.colour_   = note_colour_->value();
 

--- a/src/plugin/viewport_overlay/annotations/src/annotations_ui_plugin.cpp
+++ b/src/plugin/viewport_overlay/annotations/src/annotations_ui_plugin.cpp
@@ -648,6 +648,43 @@ void AnnotationsUI::redo(const std::string viewport_name) {
 
 bool AnnotationsUI::pointer_event(const ui::PointerEvent &e) {
 
+    if (e.modifiers() & ui::ShiftModifier) {
+        // user is holding shift key ... forward pointer events to the current
+        // playhead so that frame scrubbing can occur
+
+        if (e.type() == ui::EventType::ButtonDown && e.buttons() == ui::Signature::Button::Left) {
+            set_viewport_cursor("");
+        } else if (e.type() == ui::EventType::ButtonRelease) {
+            if (current_tool() != Text) {
+                set_viewport_cursor("Qt.CrossCursor");
+            } else {
+                set_viewport_cursor("Qt.IBeamCursor");
+            }
+        }
+
+        const std::string &viewport_name = e.context();
+
+        // get the 'global_playhead_events_actor' which keeps track of playehads
+        // and viewports
+        auto playhead_events_actor =
+            system().registry().template get<caf::actor>(global_playhead_events_actor);
+
+        // get the playhead for the given viewport
+        mail(viewport_playhead_atom_v, viewport_name).request(playhead_events_actor, infinite).then(
+            [=](caf::actor playhead) {
+                // forward the pointer event to the playhead so it can do
+                // the frame scrubbing
+                if (playhead) {
+                    anon_mail(ui::keypress_monitor::mouse_event_atom_v, e).send(playhead);
+                }
+            },
+            [=](caf::error &err) {
+                spdlog::warn("AnnotationsUI failed to forward pointer event to playhead: {}",
+                             to_string(err));
+            });
+        return false;
+    }
+
     if (current_tool() == None)
         return false;
 
@@ -807,7 +844,13 @@ void AnnotationsUI::viewport_dockable_widget_activated(std::string &widget_name)
 void AnnotationsUI::viewport_dockable_widget_deactivated(std::string &widget_name) {
 
     if (widget_name == "Annotate") {
-        active_tool_->set_value("None");
+        // if the active tool is the Laser, then keep it active so
+        // it can continue to be used without the widget visible
+        if (active_tool_->value() == tool_name(Laser)) {
+            last_tool_ = Laser;
+        } else {
+            active_tool_->set_value("None");
+        }
     }
 }
 


### PR DESCRIPTION
Annotations now create the associated note with the subject text the same as when notes are created by other means (ie. the ';' hotkey or from within the notes viewer).

When annotating, holding down the shift key now forwards all mouse events to the viewport so frames can be scrubbed without leaving annotation mode.

When leaving annotation mode, if the active tool is Laser then it will remain active so that it can be used without the annotation widget being visible. I find this very useful when working in full-screen presentation mode. To disable this you need to activate the annotation widget and switch to any tool other than Laser. This change may be controversial so please comment if it should be removed from the PR or put behind a preference.
