### PR TITLE
Fix for file browser on windows, thumbnails not loading

### DIFF
--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSThumbItem.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSThumbItem.qml
@@ -73,7 +73,8 @@ Item {
 
                     Image {
                         anchors.fill: parent
-                        property var thumbSource: "image://thumbnail/file://" + thumbnailFrame
+                        property var thumbSource: thumbSrcRoot + thumbnailFrame
+                        onThumbSourceChanged: console.log("thumbSource", thumbSource)
                         source: (visibleInFlickable || loaded) ? thumbSource : ""
                         fillMode: Image.PreserveAspectFit
                         asynchronous: true

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
@@ -31,6 +31,9 @@ Item {
 
     property var previewing: previewMediaUuid != helpers.QVariantFromUuidString("") ? previewMediaUuid == currentPlayhead.mediaUuid : false
 
+    # uri requires triple slash before drive letter on Windows, since this is the root.
+    property var thumbSrcRoot: Qt.platform.os === "windows" ? "image://thumbnail/file:///" : "image://thumbnail/file://"
+
     FileSystemBrowserScanResultsModel {
         id: __scanResultsModel
         viewMode: root.viewMode


### PR DESCRIPTION
Very small fix to the URI used for thumbnail loading on Windows platform for the new filesystem browser.|

Previously the drive letter was preceded by just two forward slashes. This must be three slashes to indicate that the filesystem root is before the drive letter.