### PR TITLE
Add Escape hotkey key as a workflow reset.

### DIFF
--- a/include/xstudio/ui/qml/studio_ui.hpp
+++ b/include/xstudio/ui/qml/studio_ui.hpp
@@ -74,6 +74,8 @@ class STUDIO_QML_EXPORT StudioUI : public QMLActor {
 
     Q_INVOKABLE void loadVideoOutputPlugins();
 
+    Q_INVOKABLE void resetViewports();
+
   signals:
 
     void newSessionCreated(const QString &session_addr);

--- a/src/playhead/src/playhead_global_events_actor.cpp
+++ b/src/playhead/src/playhead_global_events_actor.cpp
@@ -428,5 +428,13 @@ void PlayheadGlobalEventsActor::init() {
                 }
             }
             return Imath::M44f();
+        },
+        [=](ui::viewport::viewport_reset_atom) {
+
+            for (const auto &p : viewports_) {
+                auto vp = p.second.viewport;
+                anon_mail(ui::viewport::viewport_reset_atom_v, true).send(vp);
+            }
+
         });
 }

--- a/src/plugin/colour_op/grading/src/qml/Grading.2/GradingOverlay.qml
+++ b/src/plugin/colour_op/grading/src/qml/Grading.2/GradingOverlay.qml
@@ -78,15 +78,12 @@ Item {
     }
     // Event handling
 
-    XsHotkey {
-        sequence: "Escape"
-        name: "Cancel Current Shape"
-        description: "Complete current polygon or unselect current shape, when making a grading mask shape in the grading tool."
-        context: "any"
-        onActivated: {
+    XsHotkeyReference {
+        hotkeyName: "Escape"
+        exclusive: construction_polygon.item.under_construction
+        onActivated: (exclusive)=> {
             construction_polygon.item.cleanupPolygon()
         }
-        componentName: "GradingTool"
     }
 
     // indicates the 'current' (hero) image in multi image layours

--- a/src/ui/qml/studio/src/studio_ui.cpp
+++ b/src/ui/qml/studio/src/studio_ui.cpp
@@ -528,3 +528,10 @@ void StudioUI::setupSnapshotViewport(const QString &playhead_addr) {
         spdlog::warn("{} {} ", __PRETTY_FUNCTION__, e.what());
     }
 }
+
+void StudioUI::resetViewports() {
+
+    auto ph_events_actor = system().registry().template get<caf::actor>(global_playhead_events_actor);
+    anon_mail(viewport::viewport_reset_atom_v).send(ph_events_actor);
+
+}

--- a/src/ui/viewport/src/viewport.cpp
+++ b/src/ui/viewport/src/viewport.cpp
@@ -1203,6 +1203,12 @@ caf::message_handler Viewport::message_handler() {
 
                 [=](viewport_reset_atom) { reset(); },
 
+                [=](viewport_reset_atom, const bool only_synced_viewports) { 
+                    if (sync_to_main_viewport_->value()) {
+                        reset(); 
+                    }
+                },
+
                 [=](fit_mode_atom, const bool reset) { revert_fit_zoom_to_previous(); },
 
                 [=](viewport_pan_atom) -> Imath::V2f { return pan(); },

--- a/ui/qml/xstudio/application/XsSessionWindow.qml
+++ b/ui/qml/xstudio/application/XsSessionWindow.qml
@@ -276,6 +276,70 @@ ApplicationWindow {
         }
     }
 
+    // Use the Escape key as a global reset-to-home by doing the following:
+    //   - stopping playback
+    //   - exiting presentation mode if active
+    //   - making the viewed container the inspected container
+    //   - resetting the compare mode to the default for viewed container type
+    //   - soloing the selection to just the single hero selected media item
+    //   - leaving pinned-source mode if active
+    XsHotkey {
+        id: escape_hotkey
+        sequence: "Escape"
+        name: "Escape"
+        description: "Escape out of multi-selection, compare-mode, and presentation."
+        context: "any"
+
+        onActivated: (context)=> {
+            currentPlayhead.playing = false
+            if (appWindow.layoutName == "Present")
+                appWindow.togglePresentationMode()
+            currentMediaContainerIndex = viewportCurrentMediaContainerIndex
+            mediaSelectionModel.soloSelection()
+
+            // TODO: use the deault mode preference
+            const type = viewedMediaSetProperties.values.typeRole
+            if (type === "Playlist") {
+                currentPlayhead.compareMode = playlist_default_compare[0] || "A/B"
+            } else if (type === "Subset") {
+                currentPlayhead.compareMode = subset_default_compare[0] || "A/B"
+            } else if (type === "Contact Sheet") {
+                currentPlayhead.compareMode = contact_sheet_default_compare[0] || "Grid"
+            } else if (type === "Timeline") {
+                currentPlayhead.compareMode = timeline_default_compare[0] || "Off"
+                currentPlayhead.pinnedSourceMode = true
+            }
+        }
+
+        XsModelProperty {
+            id: __playlist_default_compare
+            role: "valueRole"
+            index: globalStoreModel.searchRecursive("/core/playhead/playlist_default_compare", "pathRole")
+        }
+        property alias playlist_default_compare: __playlist_default_compare.value
+
+        XsModelProperty {
+            id: __subset_default_compare
+            role: "valueRole"
+            index: globalStoreModel.searchRecursive("/core/playhead/subset_default_compare", "pathRole")
+        }
+        property alias subset_default_compare: __subset_default_compare.value
+
+        XsModelProperty {
+            id: __contact_sheet_default_compare
+            role: "valueRole"
+            index: globalStoreModel.searchRecursive("/core/playhead/contact_sheet_default_compare", "pathRole")
+        }
+        property alias contact_sheet_default_compare: __contact_sheet_default_compare.value
+
+        XsModelProperty {
+            id: __timeline_default_compare
+            role: "valueRole"
+            index: globalStoreModel.searchRecursive("/core/playhead/timeline_default_compare", "pathRole")
+        }
+        property alias timeline_default_compare: __timeline_default_compare.value
+    }
+
     property alias presentation_mode_hotkey: presentation_mode_hotkey
     property alias fullscreen_hotkey: fullscreen_hotkey
 

--- a/ui/qml/xstudio/application/XsSessionWindow.qml
+++ b/ui/qml/xstudio/application/XsSessionWindow.qml
@@ -279,6 +279,7 @@ ApplicationWindow {
     // Use the Escape key as a global reset-to-home by doing the following:
     //   - stopping playback
     //   - exiting presentation mode if active
+    //.  - exiting fullscreen if not in presentation mode
     //   - making the viewed container the inspected container
     //   - resetting the compare mode to the default for viewed container type
     //   - soloing the selection to just the single hero selected media item
@@ -292,8 +293,12 @@ ApplicationWindow {
 
         onActivated: (context)=> {
             currentPlayhead.playing = false
+
             if (appWindow.layoutName == "Present")
                 appWindow.togglePresentationMode()
+            else if (fullscreen)
+                fullscreen = false
+
             currentMediaContainerIndex = viewportCurrentMediaContainerIndex
             mediaSelectionModel.soloSelection()
 
@@ -311,33 +316,30 @@ ApplicationWindow {
             }
         }
 
-        XsModelProperty {
-            id: __playlist_default_compare
-            role: "valueRole"
-            index: globalStoreModel.searchRecursive("/core/playhead/playlist_default_compare", "pathRole")
-        }
-        property alias playlist_default_compare: __playlist_default_compare.value
-
-        XsModelProperty {
+        XsPreference {
             id: __subset_default_compare
-            role: "valueRole"
-            index: globalStoreModel.searchRecursive("/core/playhead/subset_default_compare", "pathRole")
+            path: "/core/playhead/subset_default_compare"
         }
         property alias subset_default_compare: __subset_default_compare.value
 
-        XsModelProperty {
+        XsPreference {
             id: __contact_sheet_default_compare
-            role: "valueRole"
-            index: globalStoreModel.searchRecursive("/core/playhead/contact_sheet_default_compare", "pathRole")
+            path: "/core/playhead/contact_sheet_default_compare"
         }
         property alias contact_sheet_default_compare: __contact_sheet_default_compare.value
 
-        XsModelProperty {
+        XsPreference {
             id: __timeline_default_compare
-            role: "valueRole"
-            index: globalStoreModel.searchRecursive("/core/playhead/timeline_default_compare", "pathRole")
+            path: "/core/playhead/timeline_default_compare"
         }
         property alias timeline_default_compare: __timeline_default_compare.value
+
+        XsPreference {
+            id: __playlist_default_compare
+            path: "/core/playhead/playlist_default_compare"
+        }
+        property alias playlist_default_compare: __playlist_default_compare.value
+
     }
 
     property alias presentation_mode_hotkey: presentation_mode_hotkey

--- a/ui/qml/xstudio/application/XsSessionWindow.qml
+++ b/ui/qml/xstudio/application/XsSessionWindow.qml
@@ -314,6 +314,9 @@ ApplicationWindow {
                 currentPlayhead.compareMode = timeline_default_compare[0] || "Off"
                 currentPlayhead.pinnedSourceMode = true
             }
+
+            // reset viewports
+            studio.resetViewports()
         }
 
         XsPreference {

--- a/ui/qml/xstudio/application/model/XsSessionData.qml
+++ b/ui/qml/xstudio/application/model/XsSessionData.qml
@@ -513,6 +513,16 @@ Item {
             }
             return result;
         }
+
+        // Set the current selection to be just the single hero media currently being viewed
+        function soloSelection() {
+            if (!mediaSelectionModel.selectedIndexes.length) return;
+            var row = mediaListModelData.getRowWithMatchingRoleData(currentPlayhead.mediaUuid, "actorUuidRole")
+            mediaSelectionModel.select(
+                helpers.createItemSelection([mediaListModelData.rowToSourceIndex(row)]),
+                ItemSelectionModel.ClearAndSelect
+            )
+        }
     }
 
     // mediaListModelData will give us the filtered media list that is used

--- a/ui/qml/xstudio/model/XsPreference.qml
+++ b/ui/qml/xstudio/model/XsPreference.qml
@@ -4,8 +4,9 @@ import xstudio.qml.helpers 1.0
 XsPreferenceMap {
 	id: control
 	property string path: ""
+	property string dpath: globalStoreModel ? path : ""
 
-	onPathChanged: {
+	onDpathChanged: {
 		if(globalStoreModel)
 			index = helpers.makePersistent(globalStoreModel.searchRecursive(path, "pathRole"))
 	}


### PR DESCRIPTION
This adds an Escape hotkey that doesn the following:
  - stopping playback
  - exiting presentation mode if active
  - making the viewed container the inspected container
  - resetting the compare mode to the default for viewed container type
  - soloing the selection to just the single hero selected media item
  - leaving pinned-source mode if active

In a dailies environment, when I'm done reviewing a submission I found that I needed to go through quite a few steps before moving on to the next submission. And these step often involved a cumbersome back-and-forth between mouse and keyboard. Now when I want to move on I just hit Escape and the Down arrow key.

This is possibly a subjective improvement, but hopefully OK to merge since the Escape key is only currently used by the grading tool to cancel construction of a polygon mask shape. This commit includes a modification to that code so that it works when needed without doubling up.
