### PR TITLE
Hotkey additions and modifications

### DIFF
--- a/ui/qml/xstudio/application/menus/file_menu/XsFileMenu.qml
+++ b/ui/qml/xstudio/application/menus/file_menu/XsFileMenu.qml
@@ -52,6 +52,13 @@ Item {
         description: "Closes the xSTUDIO session and application."
     }
 
+    XsHotkey {
+        id: preferences_hotkey
+        sequence: "Ctrl+,"
+        name: "Preferences"
+        description: "Open the preferences window."
+    }
+
     XsPreference {
         id: autoSavePath
         path: "/core/session/autosave/last_auto_save"
@@ -130,7 +137,7 @@ Item {
         model: file_functions.recentFiles
         Item {
             XsMenuModelItem {
-                text: file_functions.recentFiles[index]
+                text: file_functions.recentFiles[index].replace(/^file:\/\//, "")
                 menuPath: "File|Recent"
                 menuItemPosition: index
                 menuModelName: "main menu bar"
@@ -266,14 +273,18 @@ Item {
         menuItemPosition: 1
         menuModelName: "main menu bar"
         menuItemType: "button"
+        hotkeyUuid: preferences_hotkey.uuid
         onActivated: {
+            prefs_loader.sourceComponent = prefs_dialog
+            prefs_loader.item.visible = true
+        }
+        onHotkeyActivated: {
             prefs_loader.sourceComponent = prefs_dialog
             prefs_loader.item.visible = true
         }
         Component.onCompleted: {
             setMenuPathPosition("File|Preferences", 10.0)
         }
-
     }
 
     XsMenuModelItem {

--- a/ui/qml/xstudio/application/panels/media/functions/XsMediaListFunctions.qml
+++ b/ui/qml/xstudio/application/panels/media/functions/XsMediaListFunctions.qml
@@ -84,6 +84,17 @@ Item {
         clipboard.text = "xstudio -l '" + filenames.join("' '") +"'"
     }
 
+    function copyMediaNamesToClipboard() {
+        let result = []
+        mediaSelectionModel.selectedIndexes.forEach(
+            (element) => {
+                result.push(element.model.get(element, "nameRole"))
+            }
+        )
+
+        clipboard.text = result.join("\n")
+    }
+
     function copyFilePathsToClipboard() {
         let result = mediaSelectionModel.getSelectedMediaUrl("pathShakeRole")
         for(let i =0;i<result.length;i++) {

--- a/ui/qml/xstudio/application/panels/media/widgets/XsMediaHotKeys.qml
+++ b/ui/qml/xstudio/application/panels/media/widgets/XsMediaHotKeys.qml
@@ -36,6 +36,7 @@ XsHotkeyArea {
 
     property alias file_name_to_clipboard_hotkey: file_name_to_clipboard_hotkey
     property alias file_path_to_clipboard_hotkey: file_path_to_clipboard_hotkey
+    property alias media_name_to_clipboard_hotkey: media_name_to_clipboard_hotkey
     property alias quickview_to_clipboard_hotkey: quickview_to_clipboard_hotkey
 
     property alias add_to_new_playlist_context_hotkey: add_to_new_playlist_context_hotkey
@@ -101,10 +102,20 @@ XsHotkeyArea {
     XsHotkey {
         id: file_path_to_clipboard_hotkey
         name: "Copy File Path To Clipboard"
+        sequence: "Ctrl+C"
         description: "Copy Selected File Paths To Clipboard"
         context: hotkey_area.context
         componentName: "Media List"
         onActivated: media_list_functions.copyFilePathsToClipboard()
+    }
+
+    XsHotkey {
+        id: media_name_to_clipboard_hotkey
+        name: "Copy Media Name To Clipboard"
+        description: "Copy Selected Media Names To Clipboard"
+        context: hotkey_area.context
+        componentName: "Media List"
+        onActivated: media_list_functions.copyMediaNamesToClipboard()
     }
 
     XsHotkey {
@@ -200,6 +211,7 @@ XsHotkeyArea {
     XsHotkey {
         id: add_from_clipboard_hotkey
         name: "Add From Clipboard"
+        sequence: "Ctrl+V"
         description: "Add Media From Clipboard"
         context: hotkey_area.context
         componentName: "Media List"
@@ -233,17 +245,6 @@ XsHotkeyArea {
         componentName: "Media List"
         onActivated: media_list_functions.selectAllOffline()
     }
-
-    XsHotkey {
-        id: paste_hotkey
-        sequence: "Ctrl+V"
-        name: "Paste From Clipboard"
-        description: "Paste Clipboard Content into Media List"
-        context: hotkey_area.context
-        componentName: "Media List"
-        onActivated: file_functions.addMediaFromClipboard()
-    }
-
 
     XsHotkey {
         id: cycle_colour_hotkey

--- a/ui/qml/xstudio/application/panels/media/widgets/XsMediaListContextMenu.qml
+++ b/ui/qml/xstudio/application/panels/media/widgets/XsMediaListContextMenu.qml
@@ -270,6 +270,16 @@ XsPopupMenu {
         panelContext: btnMenu.panelContext
     }
 
+    XsMenuModelItem {
+        menuPath: "Copy To Clipboard"
+        text: "Selected Media Names"
+        menuItemPosition: 3
+        menuModelName: btnMenu.menu_model_name
+        hotkeyUuid: hotkey_area.media_name_to_clipboard_hotkey.uuid
+        onActivated: media_list_functions.copyMediaNamesToClipboard()
+        panelContext: btnMenu.panelContext
+    }
+
     Repeater {
         model: DelegateModel {
             model:columns_root_model

--- a/ui/qml/xstudio/application/panels/timeline/XsTimeline.qml
+++ b/ui/qml/xstudio/application/panels/timeline/XsTimeline.qml
@@ -58,7 +58,7 @@ Rectangle {
     property alias move_track_up_hotkey: move_track_up_hotkey
     property alias move_track_down_hotkey: move_track_down_hotkey
     property alias remove_items_hotkey: remove_items_hotkey
-
+    property alias add_marker_hotkey: add_marker_hotkey
 
 
 
@@ -1328,8 +1328,17 @@ Rectangle {
     }
 
     XsHotkey {
+        id: add_marker_hotkey
+        context: "any"
+        sequence: "Ctrl+M"
+        name: "Add Marker"
+        description: "Add new timeline marker on current frame."
+        componentName: "Timeline"
+    }
+
+    XsHotkey {
         id: next_marker
-        context: hotkey_area_id
+        context: "any"
         sequence:  "Ctrl+RIGHT"
         name: "Jump To Next Marker"
         description: "Jump To Next Marker"
@@ -1339,7 +1348,7 @@ Rectangle {
 
     XsHotkey {
         id: previous_marker
-        context: hotkey_area_id
+        context: "any"
         sequence:  "Ctrl+LEFT"
         name: "Jump To Previous Marker"
         description: "Jump To Previous Marker"

--- a/ui/qml/xstudio/application/panels/timeline/XsTimeline.qml
+++ b/ui/qml/xstudio/application/panels/timeline/XsTimeline.qml
@@ -733,7 +733,7 @@ Rectangle {
         theSessionData.set(index, name, "nameRole")
     }
 
-    function splitClips(indexes, frame=timelinePlayhead.logicalFrame) {
+    function splitClips(indexes=[], frame=timelinePlayhead.logicalFrame) {
         if(!indexes.length) {
             let cind = theSessionData.getTimelineClipIndex(timeline_items.rootIndex, timelinePlayhead.logicalFrame)
             if(cind.valid)
@@ -1325,6 +1325,16 @@ Rectangle {
             else
                 updateItemSelectionHorizontal(1,-1)
         }
+    }
+
+    XsHotkey {
+        id: split_clips_hotkey
+        context: "any"
+        sequence:  "Meta+S"
+        name: "Split Clip"
+        description: "Split timeline clip at current frame"
+        onActivated: splitClips()
+        componentName: "Timeline"
     }
 
     XsHotkey {

--- a/ui/qml/xstudio/application/panels/timeline/menus/XsTimelineMenu.qml
+++ b/ui/qml/xstudio/application/panels/timeline/menus/XsTimelineMenu.qml
@@ -22,6 +22,10 @@ XsPopupMenu {
               new_name
             );
         }
+
+        // When hitting Return within the dialog instead of pressing the "Add" button the
+        // keyboard focus is in limbo, so force it back to the the timeline
+        theTimeline.forceActiveFocus()
     }
 
     function createTracks(items, video=true) {
@@ -56,6 +60,7 @@ XsPopupMenu {
         menuItemPosition: 1
         menuModelName: timelineMenu.menu_model_name
         panelContext: timelineMenu.panelContext
+        hotkeyUuid: add_marker_hotkey.uuid
         onActivated: {
             dialogHelpers.textInputDialog(
                 timelineMenu.addMarker,
@@ -64,7 +69,16 @@ XsPopupMenu {
                 "Marker",
                 ["Cancel", "Add"])
         }
-    }
+        onHotkeyActivated: {
+           if (theTimeline.have_timeline && isPlayheadActive)
+               dialogHelpers.textInputDialog(
+                   timelineMenu.addMarker,
+                   "Add Marker",
+                   "Enter a name.",
+                   "Marker",
+                   ["Cancel", "Add"])
+        }
+   }
 
    XsMenuModelItem {
         text: qsTr("Hide Markers")


### PR DESCRIPTION
Added a hotkey for opening the preferences manager with "Control+," as its default sequence. Not hotkey related but in the same file is a change to strip the "file://" prefixes from the recent files menu. This is a UI-only change.

Added a hotkey and menu itme (with no default sequence) for copying selected media item's names to the clipboard. Our pipeline sets the name to a simple version identifier (ie. "myproj/shots/myscene/myshot/99") that we use both in communications as well as pasting into various apps.

Removed the paste_hotkey as it was redundant with the add_from_clipboard_hotkey. Moved the "Ctrl+V" default sequence over as well.

Added "Ctrl+C" as a default sequence to the file_path_to_clipboard_hotkey to complement the default "Ctrl+V" hotkey.

Added a hotkey to add a timeline marker with "Ctrl+M" as its default sequence. Note this uses "any" as the context since I find I often want to use this while the mouse is over the viewport. This also includes a fix for when the Return key is used to accept and close the Add Marker dialog since the focus didn't return to the app.

Likewise changed the next_marker an previous_marker hotkeys to be "any" as I found it frustrating having to always relocate the mouse to use them. Happy to keep this an internal modification if needed.