### PR TITLE
Add workflow to prevent PRs to main branch

### DIFF
--- a/.github/workflows/prevent-pr-onto-main-branch.yml
+++ b/.github/workflows/prevent-pr-onto-main-branch.yml
@@ -1,0 +1,17 @@
+name: Prevent PRs made to main branch except from develop branch
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+jobs:
+  check-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branches
+        run: |
+          if [ ${{ github.head_ref }} != "develop" ] && [ ${{ github.base_ref }} == "main" ]; then
+            echo "Merge requests to main branch are only allowed from develop branch. Please rebase your commits to the develop branch and submit a new pull request"
+            exit 1
+          fi


### PR DESCRIPTION
The main branch is protected and only intended for verified release versions of xSTUDIO. As such, all pull requests must be made onto the develop branch. Only PRs from develop are allowed onto main branch.