### PR TITLE
Add PR branch check workflow.

### DIFF
--- a/.github/workflows/prevent-pr-onto-main-branch.yml
+++ b/.github/workflows/prevent-pr-onto-main-branch.yml
@@ -1,0 +1,17 @@
+name: Prevent PRs made to main branch except from develop branch
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+jobs:
+  check-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branches
+        run: |
+          if [ ${{ github.head_ref }} != "develop" ] && [ ${{ github.base_ref }} == "main" ]; then
+            echo "Merge requests to main branch are only allowed from develop branch. Please rebase your commits to the develop branch and submit a new pull request"
+            exit 1
+          fi


### PR DESCRIPTION
This PR adds in a GitHub workflow action that allows us to reject PRs made onto the **main** branch with a helpful error informing the developer that only PRs are allowed onto the develop branch, except when merging develop into main.

This allows us to 'protect' the main branch for production tested release versions only while development contributions and activity will be managed on the develop branch.