### PR TITLE
feat(annotations): broadcast stroke events to plugin_events_group

### DIFF
--- a/python/src/xstudio/plugin/plugin_base.py
+++ b/python/src/xstudio/plugin/plugin_base.py
@@ -296,7 +296,7 @@ class PluginBase(ModuleBase):
             raise Exception("Actor has no event group.")
 
         return self.connection.link.add_message_callback(
-            event_group, callback_method
+            event_group, callback_method, plugin.remote
             )
 
     def register_ui_panel_qml(self,

--- a/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.cpp
+++ b/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.cpp
@@ -1291,13 +1291,34 @@ void AnnotationsCore::broadcast_live_stroke(
     if (user_edit_data->live_stroke)
         anno->canvas().append_item(*(user_edit_data->live_stroke));
 
-    mail(
-        utility::event_atom_v,
-        annotation_data_atom_v,
-        AnnotationBasePtr(anno),
-        user_id,
-        stroke_completed)
+    AnnotationBasePtr anno_ptr(anno);
+
+    mail(utility::event_atom_v, annotation_data_atom_v, anno_ptr, user_id, stroke_completed)
         .send(live_edit_event_group_);
+
+    // Python-accessible event: AnnotationBasePtr is not Python-bound, so broadcast
+    // the serialised geometry via plugin_events_ so Python plugins can render
+    // in-progress strokes directly, without polling/hot-scanning bookmarks.
+    // Shapes (as opposed to pen/brush strokes) are only broadcast on pen-up,
+    // since a shape isn't a meaningful annotation until the drag completes.
+    const bool is_shape = user_edit_data->item_type == Canvas::ItemType::Square ||
+                           user_edit_data->item_type == Canvas::ItemType::Circle ||
+                           user_edit_data->item_type == Canvas::ItemType::Arrow ||
+                           user_edit_data->item_type == Canvas::ItemType::Line ||
+                           user_edit_data->item_type == Canvas::ItemType::Ellipse;
+
+    if (!is_shape || stroke_completed) {
+        utility::Uuid plugin_uuid;
+        utility::JsonStore anno_json = anno_ptr->serialise(plugin_uuid);
+
+        mail(
+            utility::event_atom_v,
+            annotation_data_atom_v,
+            anno_json,
+            user_id,
+            stroke_completed)
+            .send(plugin_events_group());
+    }
 }
 
 void AnnotationsCore::broadcast_live_laser_stroke(


### PR DESCRIPTION
## Summary
Broadcasts in-progress annotation stroke **geometry** to `plugin_events_group()`
so Python plugins can render partial strokes directly from event data, instead
of polling/scanning bookmarks.

`AnnotationBasePtr` is not Python-bound, so Python plugins can't subscribe to
`live_edit_event_group` directly. This serialises the cumulative in-progress
stroke via `Annotation::serialise()` and broadcasts it as a `JsonStore`
alongside `(event_atom, annotation_data_atom, user_id, stroke_completed)`.
Shapes (Square/Circle/Arrow/Line/Ellipse) are broadcast only on pen-up, since a
shape isn't meaningful until the drag completes.

Also updates `subscribe_to_plugin_events` (plugin_base.py) to pass the plugin's
actor as the owner actor (3rd arg): `BroadcastActor` forwards via
`send_as(current_sender(), ...)`, so a Python subscriber sees the owning actor
as sender, not the broadcast group — the 2-arg form silently dropped
`plugin_events_` messages.

## Depends on #303
The `plugin_base.py` change relies on the owner-actor routing added in
**#303** (`EventToPythonThreadLockerActor` / `add_message_callback` 3rd arg).
Please review/merge #303 first.

## Changes
- `annotations_core_plugin.cpp`: broadcast serialised stroke geometry via
  `plugin_events_group()`; shapes only on pen-up.
- `plugin_base.py`: `subscribe_to_plugin_events` passes the owner actor as the
  3rd arg to `add_message_callback`.

This was developed with the assistance of claude code.
