### PR TITLE
OCIO: don't discard resolved view when pipeline instance has no display (thumbnails / offscreen renders)

### DIFF
--- a/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
@@ -594,10 +594,16 @@ OCIO::TransformRcPtr OCIOEngine::display_transform(
     if (!bypass) {
         std::string _display = display;
         std::string _view    = view;
-        if (display.empty() or view.empty()) {
+        // Fill display and view INDEPENDENTLY (same fix as process_thumbnail):
+        // offscreen/snapshot viewport pipeline instances are never attached to
+        // a physical display so their Display attribute is empty; the combined
+        // `display.empty() or view.empty()` check then discarded a valid
+        // caller-supplied view (e.g. 'raw' for un-tone-mapped media) and
+        // double-graded offscreen renders such as annotation exports.
+        if (_display.empty())
             _display = ocio_config->getDefaultDisplay();
-            _view    = ocio_config->getDefaultView(_display.c_str());
-        }
+        if (_view.empty())
+            _view = ocio_config->getDefaultView(_display.c_str());
 
         OCIO::DisplayViewTransformRcPtr dt = OCIO::DisplayViewTransform::Create();
         dt->setSrc(working_space(src_colour_mgmt_metadata).c_str());

--- a/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
+++ b/src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp
@@ -144,13 +144,19 @@ thumbnail::ThumbnailBufferPtr OCIOEngine::process_thumbnail(
 
     std::string _display = display;
     std::string _view    = view;
-    if (display.empty() or view.empty()) {
+    // Fill display and view INDEPENDENTLY. The dedicated 'thumbnail_processor'
+    // OCIO instance is never attached to a viewport/media source, so its Display
+    // attribute is empty; the old combined `display.empty() or view.empty()`
+    // check then reset _view to the config default view (e.g. Client-look),
+    // double-grading raw / display-referred media in thumbnails. Only fill in a
+    // value that is actually empty so a valid caller-supplied view survives.
+    if (_display.empty())
         _display = ocio_config->getDefaultDisplay();
-        _view    = ocio_config->getDefaultView(_display.c_str());
-    }
+    if (_view.empty())
+        _view = ocio_config->getDefaultView(_display.c_str());
 
     auto to_lin_group =
-        make_to_lin_processor(src_colour_mgmt_metadata, view, untonemapped_mode, false)
+        make_to_lin_processor(src_colour_mgmt_metadata, _view, untonemapped_mode, false)
             ->createGroupTransform();
     auto to_display_group =
         make_display_processor(src_colour_mgmt_metadata, _display, _view, false)


### PR DESCRIPTION
## Summary

Fixes thumbnails and offscreen renders being processed with the wrong OCIO view whenever the colour pipeline instance has no display attached.

- Colour pipeline instances that never attach to a physical display — the dedicated thumbnail processor and offscreen/snapshot viewport instances — always have an empty Display attribute
- `OCIOEngine::process_thumbnail()` and `OCIOEngine::display_transform()` reset **both** display **and** view to the config defaults when **either** is empty, so the correctly resolved per-media view is silently discarded for those instances
- Media flagged by a media hook with `untonemapped_view` (e.g. display-referred dailies MOVs) get the config's default view applied on top of their baked-in look — a double grade — in thumbnails (media list, notes panel) and offscreen renders (snapshots, annotation exports). The interactive viewport is unaffected because its Display attribute is populated, which makes the defect easy to miss

## Changes

- `src/plugin/colour_pipeline/ocio/src/ocio_engine.cpp`: in `process_thumbnail()` and `display_transform()`, fill display and view independently — substitute the config default only for the component that is actually empty, so a valid caller-supplied view survives an empty display (and vice versa). In `process_thumbnail()`, also pass the filled `_view` to `make_to_lin_processor()` instead of the original (possibly empty) `view`, keeping the to-linear and display halves of the transform consistent
- No behaviour change for pipeline instances with a populated display and view

## Testing

- Verified in production at RodeoFX on top of v1.3.0 with a media hook that sets `untonemapped_view` for display-referred QuickTimes: media-panel thumbnails, notes-panel thumbnails and annotation exports now render with the resolved per-media view instead of the config default
- Interactive viewport behaviour unchanged
- The patch cherry-picks cleanly between v1.3.0 and `develop` (the affected code is identical in both)
