### PR TITLE
feat(python): expose viewport scale and pan atoms

### DIFF
--- a/python/src/xstudio/api/intrinsic/viewport.py
+++ b/python/src/xstudio/api/intrinsic/viewport.py
@@ -4,6 +4,7 @@ from xstudio.core import viewport_playhead_atom, quickview_media_atom
 from xstudio.core import UuidActorVec, UuidActor, viewport_atom
 from xstudio.core import get_global_playhead_events_atom, active_viewport_atom
 from xstudio.core import URI, render_viewport_to_image_atom
+from xstudio.core import viewport_scale_atom, viewport_pan_atom, Vec2f
 from xstudio.api.session.playhead import Playhead
 from xstudio.api.module import ModuleBase
 from xstudio.api.intrinsic.colour_pipeline import ColourPipeline
@@ -85,6 +86,47 @@ class Viewport(ModuleBase):
             position[1],
             size[0],
             size[1])
+
+    @property
+    def scale(self):
+        """Get the raw viewport scale (image_pixels / viewport_pixels).
+        A larger value means more zoomed in. At fit-to-window this is typically 5-15,
+        not 1.0 — capture a baseline at fit-to-window to normalise if needed.
+
+        Returns:
+            float: Raw scale value.
+        """
+        return self.connection.request_receive(self.remote, viewport_scale_atom())[0]
+
+    @scale.setter
+    def scale(self, value):
+        """Set the raw viewport scale.
+
+        Args:
+            value(float): Raw scale value (image_pixels / viewport_pixels).
+        """
+        self.connection.send(self.remote, viewport_scale_atom(), float(value))
+
+    @property
+    def pan(self):
+        """Get the viewport pan offset as an (x, y) tuple.
+
+        Returns:
+            tuple(float, float): Pan offset in viewport-space units.
+        """
+        v = self.connection.request_receive(self.remote, viewport_pan_atom())[0]
+        return (v.x, v.y)
+
+    @pan.setter
+    def pan(self, value):
+        """Set the viewport pan offset.
+
+        Args:
+            value(tuple(float, float) or Vec2f): Pan offset as (x, y).
+        """
+        if isinstance(value, (tuple, list)):
+            value = Vec2f(float(value[0]), float(value[1]))
+        self.connection.send(self.remote, viewport_pan_atom(), value)
 
     def set_playhead(self, playhead):
         """Set the playhead that is delivering frames to the viewport, i.e.

--- a/python/src/xstudio/api/intrinsic/viewport.py
+++ b/python/src/xstudio/api/intrinsic/viewport.py
@@ -4,7 +4,7 @@ from xstudio.core import viewport_playhead_atom, quickview_media_atom
 from xstudio.core import UuidActorVec, UuidActor, viewport_atom
 from xstudio.core import get_global_playhead_events_atom, active_viewport_atom
 from xstudio.core import URI, render_viewport_to_image_atom
-from xstudio.core import viewport_scale_atom, viewport_pan_atom, Vec2f
+from xstudio.core import viewport_scale_atom, viewport_pan_atom, V2f
 from xstudio.api.session.playhead import Playhead
 from xstudio.api.module import ModuleBase
 from xstudio.api.intrinsic.colour_pipeline import ColourPipeline
@@ -122,10 +122,10 @@ class Viewport(ModuleBase):
         """Set the viewport pan offset.
 
         Args:
-            value(tuple(float, float) or Vec2f): Pan offset as (x, y).
+            value(tuple(float, float) or V2f): Pan offset as (x, y).
         """
         if isinstance(value, (tuple, list)):
-            value = Vec2f(float(value[0]), float(value[1]))
+            value = V2f(float(value[0]), float(value[1]))
         self.connection.send(self.remote, viewport_pan_atom(), value)
 
     def set_playhead(self, playhead):

--- a/src/python_module/src/py_atoms.cpp
+++ b/src/python_module/src/py_atoms.cpp
@@ -389,6 +389,8 @@ void py_config::add_atoms() {
     ADD_ATOM(xstudio::ui::viewport, active_viewport_atom);
     ADD_ATOM(xstudio::ui::viewport, render_viewport_to_image_atom);
     ADD_ATOM(xstudio::ui::viewport, viewport_mask_atom);
+    ADD_ATOM(xstudio::ui::viewport, viewport_scale_atom);
+    ADD_ATOM(xstudio::ui::viewport, viewport_pan_atom);
 
     ADD_ATOM(xstudio::ui, show_message_box_atom);
     ADD_ATOM(xstudio::ui, open_quickview_window_atom);

--- a/src/python_module/src/py_messages.cpp
+++ b/src/python_module/src/py_messages.cpp
@@ -47,7 +47,7 @@ extern void register_URI_class(py::module &m, const std::string &name);
 extern void register_FrameRateDuration_class(py::module &m, const std::string &name);
 extern void register_vector3_class(py::module &m, const std::string &name);
 extern void register_matrix44_class(py::module &m, const std::string &name);
-extern void register_vec2f_class(py::module &m, const std::string &name);
+extern void register_vector2_class(py::module &m, const std::string &name);
 extern void register_colour_triplet_class(py::module &m, const std::string &name);
 extern void register_uuid_actor_class(py::module &m, const std::string &name);
 extern void register_uuid_actor_vector_class(py::module &m, const std::string &name);
@@ -208,6 +208,6 @@ void py_config::add_messages() {
     add_message_type<xstudio::ui::viewport::Mask>(
         "Mask", "xstudio::ui::viewport::Mask", &register_mask_class);
 
-    add_message_type<Imath::V2f>("Vec2f", "Imath::V2f", &register_vec2f_class);
+    add_message_type<Imath::V2f>("V2f", "Imath::V2f", &register_vector2_class);
 }
 } // namespace caf::python

--- a/src/python_module/src/py_messages.cpp
+++ b/src/python_module/src/py_messages.cpp
@@ -15,6 +15,7 @@
 #include "xstudio/ui/mouse.hpp"
 #include "xstudio/ui/mouse.hpp"
 #include "xstudio/ui/viewport/mask.hpp"
+#include <Imath/ImathVec.h>
 #include "xstudio/utility/container.hpp"
 #include "xstudio/utility/helpers.hpp"
 #include "xstudio/utility/media_reference.hpp"
@@ -46,6 +47,7 @@ extern void register_URI_class(py::module &m, const std::string &name);
 extern void register_FrameRateDuration_class(py::module &m, const std::string &name);
 extern void register_vector3_class(py::module &m, const std::string &name);
 extern void register_matrix44_class(py::module &m, const std::string &name);
+extern void register_vec2f_class(py::module &m, const std::string &name);
 extern void register_colour_triplet_class(py::module &m, const std::string &name);
 extern void register_uuid_actor_class(py::module &m, const std::string &name);
 extern void register_uuid_actor_vector_class(py::module &m, const std::string &name);
@@ -205,5 +207,7 @@ void py_config::add_messages() {
 
     add_message_type<xstudio::ui::viewport::Mask>(
         "Mask", "xstudio::ui::viewport::Mask", &register_mask_class);
+
+    add_message_type<Imath::V2f>("Vec2f", "Imath::V2f", &register_vec2f_class);
 }
 } // namespace caf::python

--- a/src/python_module/src/py_register.cpp
+++ b/src/python_module/src/py_register.cpp
@@ -490,9 +490,9 @@ void register_matrix44_class(py::module &m, const std::string &name) {
         .def("__str__", str_impl);
 }
 
-void register_vec2f_class(py::module &m, const std::string &name) {
+void register_vector2_class(py::module &m, const std::string &name) {
     auto str_impl = [](const Imath::V2f &v) {
-        return "Vec2f(" + std::to_string(v.x) + ", " + std::to_string(v.y) + ")";
+        return "V2f(" + std::to_string(v.x) + ", " + std::to_string(v.y) + ")";
     };
     py::class_<Imath::V2f>(m, name.c_str())
         .def(py::init<>())

--- a/src/python_module/src/py_register.cpp
+++ b/src/python_module/src/py_register.cpp
@@ -33,6 +33,7 @@ CAF_POP_WARNINGS
 #include "xstudio/utility/frame_range.hpp"
 #include "xstudio/utility/notification_handler.hpp"
 #include "xstudio/ui/viewport/mask.hpp"
+#include <Imath/ImathVec.h>
 
 
 namespace py = pybind11;
@@ -487,6 +488,19 @@ void register_matrix44_class(py::module &m, const std::string &name) {
                 s[i][3] = v[3];
             })
         .def("__str__", str_impl);
+}
+
+void register_vec2f_class(py::module &m, const std::string &name) {
+    auto str_impl = [](const Imath::V2f &v) {
+        return "Vec2f(" + std::to_string(v.x) + ", " + std::to_string(v.y) + ")";
+    };
+    py::class_<Imath::V2f>(m, name.c_str())
+        .def(py::init<>())
+        .def(py::init<float, float>())
+        .def_readwrite("x", &Imath::V2f::x)
+        .def_readwrite("y", &Imath::V2f::y)
+        .def("__str__", str_impl)
+        .def("__repr__", str_impl);
 }
 
 void register_colour_triplet_class(py::module &m, const std::string &name) {


### PR DESCRIPTION
## What
Exposes the existing C++ `viewport_scale_atom` / `viewport_pan_atom` to the
Python API as read/write `Viewport.scale` (float) and `Viewport.pan` (`(x, y)`)
properties, and registers `Imath::V2f` as a Python message type (`V2f`) so pan
values marshal across the C++/Python boundary.

Inspired from https://github.com/tedwaine/xstudio/commit/2f6c66a6e6885352bc52d9552c09236e8b59e976 (extensions_for_sam branch) but ensuring we can get numbers back rather than just strings.

## Why
Both atoms already exist in `viewport.cpp` but were not reachable from Python,
so scripts/plugins had no direct way to read or drive viewport zoom/pan — the
only path was `serialise_atom`/`deserialise_atom`, which is heavier and crashes
on the `Imath::V2f` pan payload. This adds a direct, typed accessor.

## Changes
- `py_atoms.cpp`: register `viewport_scale_atom`, `viewport_pan_atom`
- `py_messages.cpp` / `py_register.cpp`: register `Imath::V2f` as `V2f`, with
  readable `.x` / `.y` members
- `viewport.py`: `Viewport.scale` and `Viewport.pan` properties. `pan` getter
  returns a plain `(x, y)` tuple; setters use fire-and-forget `send`

## Notes
- Uses the `V2f` naming to match the viewport-transform convention already in
  use, while adding the `.x`/`.y` accessors and tuple-returning `pan` getter
  needed to read a value back (not just set one), plus `send`-based setters so
  a set doesn't block waiting on a reply.

## Testing
Verified a read → transport → apply round-trip: read `Viewport.scale` /
`Viewport.pan` from one xStudio instance and re-applied them on a peer via the
new setters, with values preserved.

Generated with assistance from Claude Code.