### PR TITLE
fix(python): route event-group messages sent by the owner actor

### DIFF
--- a/python/src/xstudio/api/module.py
+++ b/python/src/xstudio/api/module.py
@@ -398,7 +398,7 @@ class ModuleBase(ActorConnection, metaclass=ModuleMeta):
             raise Exception("Actor has no event group.")
 
         return self.connection.link.add_message_callback(
-            event_group, callback_method
+            event_group, callback_method, event_source.remote
             )
 
     def unsubscribe_from_event_group(self, uuid):

--- a/src/python_module/src/py_context.cpp
+++ b/src/python_module/src/py_context.cpp
@@ -23,14 +23,50 @@ class EventToPythonThreadLockerActor : public caf::event_based_actor {
         : caf::event_based_actor(cfg), context_(context) {
 
         behavior_.assign(
-            [=](xstudio::broadcast::broadcast_down_atom, const caf::actor_addr &) {
-                // TODO: self clean up
+            [=](xstudio::broadcast::broadcast_down_atom, const caf::actor_addr &addr) {
+                // A watched event-source/owner actor has died.  Purge its
+                // callbacks so a trailing in-flight message attributed to it is
+                // not dispatched to a now-stale callback.  Leaving this empty
+                // (the previous TODO) allowed execute_event_callback() to invoke
+                // callback_func() on a dead actor's entry, segfaulting (signal 11)
+                // whenever an on-screen-source switch tore down a subscribed
+                // playhead/selection actor.  Mirrors the Uuid cleanup handler.
+                auto p = actor_to_callback_uuid_.find(addr);
+                if (p != actor_to_callback_uuid_.end()) {
+                    for (const auto &cid : p->second) {
+                        callback_to_event_group_.erase(cid);
+                    }
+                    actor_to_callback_uuid_.erase(p);
+                }
             },
             [=](const xstudio::utility::Uuid &callback_id) {
                 // stop watching
 
-                // find actor that has its events forwarded to the callback with
-                // the given ID
+                // 1. Send leave broadcast if needed
+                auto eq_it = callback_to_event_group_.find(callback_id);
+                if (eq_it != callback_to_event_group_.end()) {
+                    auto events_source = eq_it->second;
+                    bool event_source_still_needed = false;
+                    for (const auto &pair : actor_to_callback_uuid_) {
+                        if (pair.first == caf::actor_cast<caf::actor_addr>(events_source)) {
+                            for (const auto &cid : pair.second) {
+                                if (cid != callback_id) {
+                                    event_source_still_needed = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (!event_source_still_needed && events_source) {
+                        mail(
+                            xstudio::broadcast::leave_broadcast_atom_v,
+                            caf::actor_cast<caf::actor>(this))
+                            .send(events_source);
+                    }
+                    callback_to_event_group_.erase(eq_it);
+                }
+
+                // 2. Erase from actor_to_callback_uuid_
                 auto p = actor_to_callback_uuid_.begin();
                 while (p != actor_to_callback_uuid_.end()) {
 
@@ -44,14 +80,6 @@ class EventToPythonThreadLockerActor : public caf::event_based_actor {
                     }
 
                     if (p->second.empty()) {
-                        // don't need to get events from this actor any more
-                        auto events_source = caf::actor_cast<caf::actor>(p->first);
-                        if (events_source) {
-                            mail(
-                                xstudio::broadcast::leave_broadcast_atom_v,
-                                caf::actor_cast<caf::actor>(this))
-                                .send(events_source);
-                        }
                         p = actor_to_callback_uuid_.erase(p);
                     } else {
                         p++;
@@ -61,6 +89,21 @@ class EventToPythonThreadLockerActor : public caf::event_based_actor {
             [=](caf::actor events_source, const xstudio::utility::Uuid &callback_id) {
                 actor_to_callback_uuid_[caf::actor_cast<caf::actor_addr>(events_source)]
                     .push_back(callback_id);
+                callback_to_event_group_[callback_id] = events_source;
+                // join the events broadcast
+                mail(
+                    xstudio::broadcast::join_broadcast_atom_v,
+                    caf::actor_cast<caf::actor>(this))
+                    .send(events_source);
+            },
+            [=](caf::actor events_source, caf::actor owner_actor, const xstudio::utility::Uuid &callback_id) {
+                actor_to_callback_uuid_[caf::actor_cast<caf::actor_addr>(events_source)]
+                    .push_back(callback_id);
+                if (owner_actor) {
+                    actor_to_callback_uuid_[caf::actor_cast<caf::actor_addr>(owner_actor)]
+                        .push_back(callback_id);
+                }
+                callback_to_event_group_[callback_id] = events_source;
                 // join the events broadcast
                 mail(
                     xstudio::broadcast::join_broadcast_atom_v,
@@ -87,6 +130,7 @@ class EventToPythonThreadLockerActor : public caf::event_based_actor {
     caf::behavior behavior_;
     py_context *context_;
     std::map<caf::actor_addr, std::vector<xstudio::utility::Uuid>> actor_to_callback_uuid_;
+    std::map<xstudio::utility::Uuid, caf::actor> callback_to_event_group_;
 
     caf::behavior make_behavior() override { return behavior_; }
 };
@@ -424,14 +468,19 @@ xstudio::utility::Uuid py_context::py_add_message_callback(const py::args &xs) {
 
     xstudio::utility::Uuid uuid = xstudio::utility::Uuid::generate();
 
-    if (xs.size() == 2) {
+    if (xs.size() == 2 || xs.size() == 3) {
 
         auto i = xs.begin();
         // this is the xstudio actor that
         auto remote_actor = (*i).cast<caf::actor>();
         i++;
         auto callback_func = (*i).cast<py::function>();
-        auto addr          = caf::actor_cast<caf::actor_addr>(remote_actor);
+
+        caf::actor owner_actor;
+        if (xs.size() == 3) {
+            i++;
+            owner_actor = (*i).cast<caf::actor>();
+        }
 
         // spawn a listener actor to receive the event messages. THis will
         // run the Python callback (after acquiring the GIL)
@@ -447,12 +496,16 @@ xstudio::utility::Uuid py_context::py_add_message_callback(const py::args &xs) {
         // here we message our 'watcher'. It will join the event group of
         // the 'remote_actor' and when it gets event messages from that actor
         // it will run the py_callback
-        anon_mail(remote_actor, uuid).send(message_callback_handler_actor_);
+        if (owner_actor) {
+            anon_mail(remote_actor, owner_actor, uuid).send(message_callback_handler_actor_);
+        } else {
+            anon_mail(remote_actor, uuid).send(message_callback_handler_actor_);
+        }
 
     } else {
         throw std::runtime_error(
-            "Set message callback expecting tuple of size 2 "
-            "(remote_event_group_actor, callack_func).");
+            "Set message callback expecting tuple of size 2 or 3 "
+            "(remote_event_group_actor, callback_func, [optional_owner_actor]).");
     }
     return uuid;
 }


### PR DESCRIPTION
## Summary
Fixes `EventToPythonThreadLockerActor` so messages broadcast by a C++ event
group are actually delivered to their Python subscribers, and prevents a
SIGSEGV when a subscribed actor is torn down mid-dispatch.

When a C++ event group broadcasts, the CAF sender is the **owner actor**
(e.g. a Playhead, Timeline, or selection actor), not the event-group actor the
Python code subscribed to. The dispatcher matched callbacks by sender address,
so those messages hit no callback and were silently dropped.

## Why it matters (general, not playhead-specific)
This affects any `subscribe_to_event_group()` consumer. Concretely, a Python
plugin that subscribes to a timeline's change events or a viewport's
current-selection events receives nothing today, so it can't detect or forward
structure/selection changes.

Reproduced end-to-end with an external sync plugin: reverting the owner-actor
argument makes an xSTUDIO-driven add-media / select / delete-media sequence
fail to propagate to a peer (our `delete_media_xstudio` integration test); it
passes with the fix.

## Changes
- Track the optional owner actor per callback ID in `EventToPythonThreadLockerActor`.
- Route an incoming message via the owner-actor address as a fallback when the
  sender matches no event-group key.
- Add a `broadcast_down_atom` handler to purge stale callback entries when a
  subscribed owner actor dies (fixes the timeline-switch SIGSEGV).
- `subscribe_to_event_group` (module.py) passes the owner actor as the 3rd arg
  to `add_message_callback` — backward compatible; the C++ side still accepts
  the 2-arg form.

## Relationship to #270
This supersedes #270, which framed the fix around *playhead* events — where the
concern was that playhead event payloads carry types not bound to Python. This
version is scoped to the general event-group routing mechanism and is
demonstrated with a non-playhead case (timeline structure / selection sync)
that carries Python-friendly data. The playhead-specific Python plumbing from
#270 is intentionally not included.

Written with assistance from Claude.