### PR TITLE
Add annotation event group to annotations tool, and subscription mech…

### DIFF
--- a/python/src/xstudio/plugin/plugin_base.py
+++ b/python/src/xstudio/plugin/plugin_base.py
@@ -6,6 +6,8 @@ from xstudio.api.auxiliary.helpers import get_event_group
 from xstudio.core import spawn_plugin_base_atom, viewport_playhead_atom
 from xstudio.core import get_global_playhead_events_atom, show_message_box_atom
 from xstudio.core import plugin_events_group_atom, get_event_group_atom, event_atom
+from xstudio.core import annotation_atom
+import json
 import sys
 import os
 import traceback
@@ -55,6 +57,7 @@ class PluginBase(ModuleBase):
         self.user_attr_handler_ = None
         self.__image_source_attr_id = None
         self.__current_playhead = None
+        self.__annotation_event_cb = None
 
     def add_attribute(
         self,
@@ -273,6 +276,46 @@ class PluginBase(ModuleBase):
             viewport_playhead_atom())[0]
         self.__connect_to_playhead(current_playhead)
 
+    def __annotation_event_msg_handler(self, msg):
+        if len(msg)==3 and isinstance(msg[2], JsonStore):
+            # the 3rd element in the message data should be an xSTUDIO JsonStore
+            # object. We convert it to a python dict via json.
+            self.__annotation_event_cb(json.loads(msg[2].dump()), None, None)
+        elif len(msg)==5 and isinstance(msg[2], JsonStore):
+            # the 3rd element in the message data should be an xSTUDIO JsonStore
+            # object. We convert it to a python dict via json.
+            self.__annotation_event_cb(json.loads(msg[2].dump()), user_id=msg[3], stroke_completed=msg[4])
+
+
+    def subscribe_to_annotation_draw_events(self, callback):
+        """Set-up a subscription to receive the granular draw events resulting
+        from user interaction with the annotation draw tools such as paint 
+        strokes, text caption editing and so-on. The full, serialised annotation
+        data
+
+         Args:
+            callback_method(Callable): The function which will be called
+            with event. The method must have the following signature:
+            def anno_event_callback(self, event_data, user_id, stroke_completed)
+
+        Returns:
+            uuid (callback id): A uuid for the subscription. Pass to
+            unsubscribe_from_event_group to cancel an event subscription
+        """
+        from inspect import signature
+        sig = signature(callback)
+        if len(sig.parameters) != 3:
+            raise Exception("Annotation draw event callback must take 3 arguments.")
+        anno_plugin = self.get_plugin("AnnotationsCore")
+        draw_events_group = self.connection.request_receive(
+            anno_plugin.remote,
+            get_event_group_atom(),
+            annotation_atom()
+            )[0]
+        self.__annotation_event_cb = callback
+        return self.connection.link.add_message_callback(
+            draw_events_group, self.__annotation_event_msg_handler
+            )
 
     def subscribe_to_plugin_events(self, plugin, callback_method):
         """Set-up a subscription to the events of an xstudio plugin.

--- a/src/plugin/data_source/demo/demo_datasource_plugin/src/demo_plugin_python/plugin.py
+++ b/src/plugin/data_source/demo/demo_datasource_plugin/src/demo_plugin_python/plugin.py
@@ -88,6 +88,20 @@ class DemoPluginPython(PluginBase):
             menu_item_position=1.5,
             divider=True)
 
+        self.sub_menu = self.insert_menu_item(
+            menu_model_name="main menu bar",
+            menu_path="Demo Plugin",
+            menu_text="Subscribe to Draw Events",
+            menu_item_position=3.0,
+            user_data="draw_subscribe")
+
+        self.unsub_menu = self.insert_menu_item(
+            menu_model_name="main menu bar",
+            menu_path="Demo Plugin",
+            menu_text="Un-subscribe from Draw Events",
+            menu_item_position=4.0,
+            user_data="draw_unsubscribe")
+
         # expose our attributes in the UI layer
         self.connect_to_ui()
 
@@ -98,11 +112,25 @@ class DemoPluginPython(PluginBase):
         self.versions_table = self.database_tables[1]
 
         self.cpp_plugin_actor = None
+        self.draw_events_subscription_id = None
 
     def attribute_changed(self, attribute, role):
 
         if attribute == self.toggle_attribute:
             print ("ATTRIBUTE CHANGE", attribute.as_json())
+
+    def draw_event_handler(self, draw_event, user_id, stroke_completed):
+        pass
+        #print("DRAW EVENT", draw_event, user_id, stroke_completed)
+
+    def menu_item_activated(self, menu_item_data, user_data):
+        if not self.draw_events_subscription_id and menu_item_data.get("user_data") == "draw_subscribe":
+            self.draw_events_subscription_id = self.subscribe_to_annotation_draw_events(
+                self.draw_event_handler
+            )
+        elif self.draw_events_subscription_id and menu_item_data.get("user_data") == "draw_unsubscribe":
+            self.unsubscribe_from_event_group(self.draw_events_subscription_id)
+            self.draw_events_subscription_id = None
 
     def cb(self):
         self.create_qml_item(custom_qml)

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSThumbItem.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSThumbItem.qml
@@ -74,7 +74,6 @@ Item {
                     Image {
                         anchors.fill: parent
                         property var thumbSource: thumbSrcRoot + thumbnailFrame
-                        onThumbSourceChanged: console.log("thumbSource", thumbSource)
                         source: (visibleInFlickable || loaded) ? thumbSource : ""
                         fillMode: Image.PreserveAspectFit
                         asynchronous: true

--- a/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.cpp
+++ b/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.cpp
@@ -48,6 +48,7 @@ AnnotationsCore::AnnotationsCore(
 
     live_edit_event_group_ = spawn<broadcast::BroadcastActor>(this);
     link_to(live_edit_event_group_);
+
 }
 
 // AnnotationsCore::~AnnotationsCore() {}
@@ -93,7 +94,15 @@ caf::message_handler AnnotationsCore::message_handler_extensions() {
         },
         [=](utility::event_atom,
             ui::viewport::annotation_atom,
-            const utility::JsonStore &data) { receive_annotation_data(data); },
+            const utility::JsonStore &data) { 
+            receive_annotation_data(data); 
+
+            if (draw_events_event_group_) {
+                // use anon_mail here, so the event 'source' is draw_events_event_group_ and not
+                // the AnnotationCorePlugin instance
+                anon_mail(utility::event_atom_v, ui::viewport::annotation_atom_v, data).send(draw_events_event_group_);
+            }
+        },
         [=](ui::viewport::annotation_atom,
             ui::viewport::viewport_atom,
             const std::string &viewport_name,
@@ -136,6 +145,18 @@ caf::message_handler AnnotationsCore::message_handler_extensions() {
             bool join) {
             // SYNC plugin uses this so it gets updates on live annotations as they are drawn
             anon_mail(broadcast::join_broadcast_atom_v, joiner).send(live_edit_event_group_);
+        },
+        [=](utility::get_event_group_atom,
+            ui::viewport::annotation_atom) -> caf::actor {
+            // This message allows other components (notably python plugins) to join a special
+            // event group that forwards all draw interaction events incoming to the plugin.
+            // Thus the 3rd party component can get all updates on annotation strokes.
+            if (!draw_events_event_group_) {
+                draw_events_event_group_ = spawn<broadcast::BroadcastActor>(this);
+                link_to(draw_events_event_group_);
+            }
+            return draw_events_event_group_;
+
         });
 }
 
@@ -1291,13 +1312,43 @@ void AnnotationsCore::broadcast_live_stroke(
     if (user_edit_data->live_stroke)
         anno->canvas().append_item(*(user_edit_data->live_stroke));
 
+    AnnotationBasePtr anno_ptr(anno);
+
     mail(
         utility::event_atom_v,
         annotation_data_atom_v,
-        AnnotationBasePtr(anno),
+        anno_ptr,
         user_id,
         stroke_completed)
         .send(live_edit_event_group_);
+
+    if (draw_events_event_group_) {
+        // Here we send the whole, serialised annotation data. This can be consumed
+        // by a Python plugin implementing annotation event syncing, for example.
+        // TODO: full python bindings for AnnotationBasePtr to avoid expensive 
+        // serialisation
+        const bool is_shape = user_edit_data->item_type == Canvas::ItemType::Square ||
+                            user_edit_data->item_type == Canvas::ItemType::Circle ||
+                            user_edit_data->item_type == Canvas::ItemType::Arrow ||
+                            user_edit_data->item_type == Canvas::ItemType::Line ||
+                            user_edit_data->item_type == Canvas::ItemType::Ellipse;
+
+        if (!is_shape || stroke_completed) {
+            
+            utility::Uuid plugin_uuid;
+            utility::JsonStore anno_json = anno_ptr->serialise(plugin_uuid);
+            anno_json["user_id"] = user_id;
+            anno_json["stroke_completed"] = stroke_completed;
+            // anon mail
+            anon_mail(
+                utility::event_atom_v,
+                annotation_data_atom_v,
+                anno_json,
+                user_id,
+                stroke_completed)
+                .send(draw_events_event_group_);
+        }        
+    }
 }
 
 void AnnotationsCore::broadcast_live_laser_stroke(

--- a/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.hpp
+++ b/src/plugin/viewport_overlay/annotations/src/annotations_core_plugin.hpp
@@ -206,6 +206,7 @@ class AnnotationsCore : public plugin::StandardPlugin {
     std::map<std::string, std::atomic_int *> hide_strokes_per_viewport_;
     std::map<std::string, std::atomic_bool *> hide_all_per_viewport_;
     caf::actor live_edit_event_group_;
+    caf::actor draw_events_event_group_;
     utility::Uuid current_edited_annotation_uuid_;
 
     const media_reader::ImageBufDisplaySetPtr &


### PR DESCRIPTION
This change is provided to allow a python plugin to receive granular annotation draw events when a user is doing draw-overs in the xSTUDIO viewport.

A method is added to the python plugin base class that allows it to subscribe to draw events by passing a callback function.

Note that when a paint stroke is being constructed the reciever will receive both the 'raw' paint start/ paint point/ paint end events plus the full serialisation data for the annotation stroke. Use the appropriate event data as required.

Example usage is provided in this file: 

src/plugin/data_source/demo/demo_data_source_plugin/src/demo_python_plugin/plugin.py