### PR TITLE
feat(filesystem_browser): various feature additions and fixes.

### DIFF
--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSDirectoryTreeBody.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSDirectoryTreeBody.qml
@@ -61,7 +61,7 @@ Item {
     }
 
     function stripTrailingPathSeparator(p) {
-        p = p.endsWith(pathSep) ? p.slice(0, -pathSep.length) : p
+        p = p && p.endsWith(pathSep) ? p.slice(0, -pathSep.length) : p
         return p;
     }
 
@@ -521,16 +521,23 @@ Item {
                             anchors.fill: parent
                             hoverEnabled: true
                             acceptedButtons: Qt.LeftButton
-                            onClicked: sendCommand({"action": "force_scan", "path": model.path})
+                            onClicked: {
+                                sendCommand({"action": "force_scan", "path": model.path})
+                                wasClicked = true
+                            }
                         }
                         visible: isHovered && !model.isLoading
                     }
                     
                     // Loading Indicator
-                    XsText {
-                        text: "..."
-                        visible: model.isLoading
+                    BusyIndicator {
+                        id: busy
+                        Layout.fillHeight: true
                         Layout.rightMargin: 5
+                        implicitWidth: height
+                        running: model.isLoading
+                        visible: running
+                        palette.dark: XsStyleSheet.primaryTextColor
                     }
                 }
                 

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSMainHeader.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSMainHeader.qml
@@ -43,6 +43,24 @@ Rectangle {
             hint: "Filter String ..."
         }
 
+        XsCheckBox {
+            id: expandCheck
+            Layout.alignment: Qt.AlignVCenter
+            text: "Expand Sequences"
+            checked: false
+            onCheckedChanged: {
+                if (deepScan)
+                    deepScan = false
+                sendCommand({"action": "change_path", "path": current_path_attr.value})
+            }
+        }
+
+        XsAttributeValue {
+            attributeTitle: "expand_sequences"
+            model: pluginData
+            value: expandCheck.checked
+        }
+
         XsPrimaryButton {
             Layout.fillHeight: true
             visible: searching_attr.value === true

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSPathInput.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSPathInput.qml
@@ -14,6 +14,18 @@ RowLayout {
     spacing: 1
     property var completionList: []
     
+    function getCommonPrefix(strings) {
+        if (!strings || strings.length === 0) return "";
+        var prefix = strings[0];
+        for (var i = 1; i < strings.length; i++) {
+            while (strings[i].indexOf(prefix) !== 0) {
+                prefix = prefix.substring(0, prefix.length - 1);
+                if (prefix === "") return "";
+            }
+        }
+        return prefix;
+    }
+
     XsPrimaryButton {
         
         Layout.preferredHeight: XsStyleSheet.primaryButtonStdHeight

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSTreeView.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSTreeView.qml
@@ -68,6 +68,7 @@ Flickable {
         thumbsModel: scanResultsModel
         property var is_folder: true
         property var name: ""
+        property var name_and_count: ""
         property var frames: ""
         property var owner: ""
         property var date_string: ""

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
@@ -34,6 +34,11 @@ Item {
     // uri requires triple slash before drive letter on Windows, since this is the root.
     property var thumbSrcRoot: Qt.platform.os === "windows" ? "image://thumbnail/file:///" : "image://thumbnail/file://"
 
+    onVisibleChanged: {
+        if (!visible)
+            sendCommand({"action": "stop_scan"})
+    }
+
     FileSystemBrowserScanResultsModel {
         id: __scanResultsModel
         viewMode: root.viewMode
@@ -442,6 +447,23 @@ Item {
         model: pluginData
     }
     
+    XsAttributeValue {
+        id: scanned_dirs_attr
+        attributeTitle: "scanned_dirs"
+        model: pluginData
+        role: "value"
+        onValueChanged: {
+             try {
+                 var val = value
+                 if (val && val !== "[]") {
+                     scannedDirsList = JSON.parse(val)
+                 } else {
+                     scannedDirsList = []
+                 }
+             } catch(e) { }
+        }
+    }
+    
     // Filters
     XsAttributeValue { 
         id: filter_time_attr
@@ -543,7 +565,7 @@ Item {
             spacing: 0
             visible: root.viewMode != 3
             function getItemAtIndex(index) {
-                return fileListView.getItemAtIndex(index)
+                return fileTreeView.getItemAtIndex(index)
             }
 
             FSListHeader {
@@ -691,8 +713,9 @@ Item {
                     onClicked: (mouse) => {
 
                         if (mouse.button === Qt.RightButton && underMouseIndex != -1) {
-                            let clickedItemPath = scanResultsModel.get(underMouseIndex, "path")
-                            thumbContextMenu.itemPath = clickedItemPath
+                            if (!selectedItems.includes(underMouseIndex)) {
+                                selectedItems = [underMouseIndex]
+                            }
                             thumbContextMenu.showMenu(
                                 mouseArea,
                                 mouse.x, mouse.y);
@@ -834,6 +857,14 @@ Item {
         id: thumbToolTip
         delay: 500
         maxWidth: 400
+
+        MouseArea {
+            anchors.fill: parent
+            propagateComposedEvents: true
+            onClicked: (mouse) => mouse.accepted = false
+            onPressed: (mouse) => mouse.accepted = false
+            onReleased: (mouse) => mouse.accepted = false
+        }
     }
 
 }

--- a/src/plugin/utility/filesystem_browser/filesystem_browser_python/config.json
+++ b/src/plugin/utility/filesystem_browser/filesystem_browser_python/config.json
@@ -1,17 +1,39 @@
 {
     "extensions": [
-        ".mov",
-        ".mp4",
-        ".mkv",
-        ".mxf",
         ".exr",
         ".jpg",
         ".jpeg",
         ".png",
         ".dpx",
-        ".tiff",
         ".tif",
+        ".tiff",
+        ".cr2",
+        ".cr3",
+        ".dng",
+        ".arw",
+        ".nef",
+        ".mov",
+        ".mp4",
+        ".mkv",
+        ".mxf",
+        ".insv",
+        ".lrv",
         ".wav",
+        ".aif",
+        ".aiff",
+        ".mp3",
+        ".pdf"
+    ],
+    "non_sequence_extensions": [
+        ".mov",
+        ".mp4",
+        ".mkv",
+        ".mxf",
+        ".insv",
+        ".lrv",
+        ".wav",
+        ".aif",
+        ".aiff",
         ".mp3",
         ".pdf"
     ],
@@ -39,5 +61,6 @@
         "/snap"
     ],
     "max_recursion_depth": 6,
-    "auto_scan_threshold": 4
+    "auto_scan_threshold": 4,
+    "follow_symlinks": false
 }

--- a/src/plugin/utility/filesystem_browser/filesystem_browser_python/filesystem_browser.py
+++ b/src/plugin/utility/filesystem_browser/filesystem_browser_python/filesystem_browser.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 Sam Richards
 
 from xstudio.plugin import PluginBase
-from xstudio.core import JsonStore, FrameList, add_media_atom, Uuid, event_atom
+from xstudio.core import Uuid, event_atom
 from xstudio.core import KeyboardModifier
 import os
 from enum import Enum
@@ -11,10 +11,8 @@ import json
 import threading
 import time
 import subprocess
-import shutil
-import pathlib
-import atexit
 import traceback
+
 class HostApp(Enum):
     generic = 1
     xstudio = 2
@@ -372,6 +370,15 @@ class FilesystemBrowserPlugin(PluginBase):
         )
         self.current_path_attr.expose_in_ui_attrs_group("Filesystem Browser")
 
+        # Attribute overriding if frames are consolidated into sequences
+        self.expand_sequences_attr = self.add_attribute(
+            "expand_sequences",
+            False,
+            {"title": "expand_sequences"},
+            register_as_preference=False
+        )
+        self.expand_sequences_attr.expose_in_ui_attrs_group("Filesystem Browser")
+
         # Attribute for commands from QML
         self.command_attr = self.add_attribute(
             "command_channel",
@@ -388,9 +395,6 @@ class FilesystemBrowserPlugin(PluginBase):
             register_as_preference=False
         )
         self.preview_media_uuid.expose_in_ui_attrs_group("Filesystem Browser")
-
-        # Action to toggle the panel
-        self.toggle_action_uuid = "2669e4a3-7186-4556-9818-80949437b018"
 
         self.toggle_browser_action = self.register_hotkey(
             self.toggle_browser, # hotkey_callback
@@ -659,6 +663,14 @@ class FilesystemBrowserPlugin(PluginBase):
         )
         self.extensions_attr.expose_in_ui_attrs_group("Filesystem Browser Settings")
 
+        self.non_sequence_extensions_attr = self.add_attribute(
+            "Non-Sequence Extensions",
+            ", ".join(self.config.get("non_sequence_extensions", [])),
+            {"title": "Non-Sequence Extensions", "category": "Filesystem Browser"},
+            register_as_preference=True
+        )
+        self.non_sequence_extensions_attr.expose_in_ui_attrs_group("Filesystem Browser Settings")
+
         self.ignore_dirs_attr = self.add_attribute(
             "Ignore Directories",
             ", ".join(self.config.get("ignore_dirs", [])),
@@ -703,6 +715,12 @@ class FilesystemBrowserPlugin(PluginBase):
     @property
     def extensions(self):
         val = self.extensions_attr.value()
+        if not val: return []
+        return [item.strip() for item in val.split(',') if item.strip()]
+
+    @property
+    def non_sequence_extensions(self):
+        val = self.non_sequence_extensions_attr.value()
         if not val: return []
         return [item.strip() for item in val.split(',') if item.strip()]
 
@@ -905,6 +923,9 @@ class FilesystemBrowserPlugin(PluginBase):
             except Exception as e:
                 import traceback
                 _dbg(f"BATCH ERROR: {e}\n{traceback.format_exc()}")
+        elif attribute.uuid == self.expand_sequences_attr.uuid and role == AttributeRole.Value:
+            if hasattr(self, 'scanner'):
+                self.scanner.expand_sequences = attribute.value()
 
     def _manual_scan_required(self):
         """Called when a path is selected that is shallow enough to require 
@@ -981,11 +1002,14 @@ class FilesystemBrowserPlugin(PluginBase):
         max_depth = custom_depth if custom_depth is not None else self.depth_limit_attr.value()
         config = {
             "extensions": list(self.extensions),
+            "non_sequence_extensions": list(self.non_sequence_extensions),
             "ignore_dirs": list(self.ignore_dirs),
-            "max_depth": max_depth
+            "max_depth": max_depth,
+            "follow_symlinks": self.config.get("follow_symlinks", False)
         }
         
         self.scanner = FileScanner(config)
+        self.scanner.expand_sequences = self.expand_sequences_attr.value()
         with self.results_lock:
             self.current_scan_results = []
         self.pending_scan_results = []
@@ -1161,16 +1185,21 @@ class FilesystemBrowserPlugin(PluginBase):
                             continue
                             
                         if entry.is_dir():
-                            # Does this hit performance of the tree? 
-                            has_subdir = False
-                            try:
-                                with os.scandir(entry.path) as sub_it:
-                                    for sub_entry in sub_it:
-                                        if sub_entry.is_dir():
-                                            has_subdir = True
-                                            break
-                            except Exception:
-                                pass
+                            # Does this hit performance of the tree?
+                            # Yes, massively for me so commenting out (ken@mcgaugh.co.uk)
+                            # Perhaps this could be run in another thread so that it
+                            # doesn't block the directory tree UI from expanding down
+                            # to the current path.
+                            has_subdir = True
+                            #has_subdir = False
+                            #try:
+                            #    with os.scandir(entry.path) as sub_it:
+                            #        for sub_entry in sub_it:
+                            #            if sub_entry.is_dir():
+                            #                has_subdir = True
+                            #                break
+                            #except Exception:
+                            #    pass
                             dirs.append({
                                 "name": entry.name,
                                 "path": entry.path,

--- a/src/plugin/utility/filesystem_browser/filesystem_browser_python/scanner.py
+++ b/src/plugin/utility/filesystem_browser/filesystem_browser_python/scanner.py
@@ -4,7 +4,6 @@
 import os
 import re
 import threading
-import queue
 import time
 import pathlib
 from datetime import datetime
@@ -12,7 +11,6 @@ try:
     import pwd
 except ImportError:
     pwd = None
-import json
 from concurrent.futures import ThreadPoolExecutor
 
 try:
@@ -23,13 +21,16 @@ except ImportError:
 class FileScanner:
     def __init__(self, config=None):
         self.config = config or {}
-        self.extensions = set(self.config.get("extensions", [".mov", ".exr", ".png", ".mp4", ".jpg", ".jpeg", ".dpx", ".tiff", ".tif"]))
         self.ignore_dirs = set(self.config.get("ignore_dirs", [".git", ".svn", "__pycache__"]))
-        self.non_sequence_extensions = set(self.config.get("non_sequence_extensions", [".mov", ".mp4"]))
+        self.extensions = set(self.config.get("extensions", [".exr", ".png", ".jpg", ".jpeg", ".dpx", ".tiff", ".tif", ".mov", ".mp4", ".mxf"]))
+        self.non_sequence_extensions = set(self.config.get("non_sequence_extensions", [".mov", ".mp4", ".mxf"])) & self.extensions
         self.version_regex = re.compile(self.config.get("version_regex", r"_v(\d+)"))
         self.max_workers = self.config.get("thread_count", 4)
         self.max_depth = self.config.get("max_depth", 6)
-        
+        self.follow_symlinks = self.config.get("follow_symlinks", False)
+
+        self.expand_sequences = False
+
         self.cancel_event = threading.Event()
         self.executor = ThreadPoolExecutor(max_workers=self.max_workers)
 
@@ -171,7 +172,7 @@ class FileScanner:
                     if self.cancel_event.is_set():
                         break
                     
-                    if entry.is_dir(follow_symlinks=False):
+                    if entry.is_dir(follow_symlinks=self.follow_symlinks):
                         if entry.name not in self.ignore_dirs and not entry.name.startswith('.'):
                             subdirs.append(entry.path)
                             # Also add directory as an item
@@ -241,6 +242,12 @@ class FileScanner:
         final_items = []
         sequence_candidate_paths = []
         
+        if not fileseq or self.expand_sequences:
+            # Treat everything as singles
+            for p, name, st, is_dir in raw_files:
+                final_items.append(self._make_item(p, name, st, start_path, is_directory=is_dir, depth=depth))
+            return self._group_versions(final_items)
+
         # Split into sequence candidates and singles
         for p, name, st, is_dir in raw_files:
             if is_dir:
@@ -255,40 +262,16 @@ class FileScanner:
                 sequence_candidate_paths.append(p)
             
         # Use fileseq to find sequences among candidates
-        # Import moved to top level or check self.HAS_FILESEQ? 
-        # The file has 'try: import fileseq ...' at top level
-        
+        # (fileseq module availability checked above)
+
         sequences = []
-        if fileseq and sequence_candidate_paths:
+        if sequence_candidate_paths:
             try:
                 sequences = fileseq.findSequencesInList(sequence_candidate_paths)
             except Exception as e:
                 sequences = [] # Fallback?
 
-        if not fileseq and sequence_candidate_paths:
-             # Fallback: Treat all as singles
-             for p in sequence_candidate_paths:
-                 info = path_map.get(p)
-                 if info:
-                    final_items.append(self._make_item(p, info[0], info[1], start_path, depth=depth))
-
         for seq in sequences:
-            # Check if we should explode this sequence (if it's actually versioned files matching config)
-            explode = False
-            
-            # If length is 1, it's virtually a single file, but fileseq wraps it.
-            # If length > 1, check if it matches version regex but shouldn't?
-            # Existing logic:
-            if len(seq) > 1:
-                try:
-                    # If the basename doesn't match version regex, but one file does??
-                    # This logic seems to prevent detecting a sequence if the naming is ambiguous?
-                    # Let's keep existing logic but careful.
-                    # Actually, if len > 1, it IS a sequence usually.
-                    pass
-                except Exception as e:
-                    pass
-            
             if len(seq) == 1:
                  # Treat as single file
                  str_p = str(seq[0])


### PR DESCRIPTION
FSDirectoryTreeBody.qml
- Replaced '...' with animated busy indicator.
- Eliminated some benign error messages.
- Prevented pressing "Full Scan" button from re-centring the direcotry list's scroll position to be consistent with just selecting the directory.

FSMainHeader.qml
- Added "Expand Sequences" toggle. When checked will disable the use of fileseq to compress frames into sequences.

FSTreeView.qml
- Added "name_and_count" property to FSDirectoryGroup item to avoid error message.

FileSystemBrowser.qml
- Added callback to automatically stop active scanning when the browser becomes hidden.
- Fixed bug preventing the scanning feedback console from working.
- Fixed copy-paste error where the fileTreeView was incorrectly calling the fileListView.getItemAtIndex().
- Modifed the right-click pop-up to select the item under the mouse if it isn't already selected to avoid confusion over which items the menus acted on.
- Modified the thumbnail tooltip to pass through any mouse events.

config.json
- Added more supported extensions.
- Exposed "non_sequence_extensions" so it can be customised.
- Exposed "follow_symlinks" so it can be customised.

filesystem_browser.py
- Removed unused imports and member variables.
- Added support for the "Expand Sequences" toggle.
- Added support for customising the "non_sequence_extensions".
- Added support for customising the "follow_symlinks".
- Commented out the scanning for subdirs-with-subdirs as it was causing the directory tree to hang for minutes at a time.

scanner.py
- Removed unused imports and member variables.
- Added support for the "Expand Sequences" toggle.
- Added support for customising the "non_sequence_extensions".
- Added support for customising the "follow_symlinks".
- Cleared out some dead code.