### PR TITLE
FileSystemBrowser.qml: fix invalid '#' comment (QML requires //)

### DIFF
--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
@@ -31,7 +31,7 @@ Item {
 
     property var previewing: previewMediaUuid != helpers.QVariantFromUuidString("") ? previewMediaUuid == currentPlayhead.mediaUuid : false
 
-    # uri requires triple slash before drive letter on Windows, since this is the root.
+    // uri requires triple slash before drive letter on Windows, since this is the root.
     property var thumbSrcRoot: Qt.platform.os === "windows" ? "image://thumbnail/file:///" : "image://thumbnail/file://"
 
     FileSystemBrowserScanResultsModel {


### PR DESCRIPTION
A python-style `#` comment in `FileSystemBrowser.qml:34` is a QML syntax error, which prevents the filesystem browser plugin's QML from loading. One-character fix.