### PR TITLE
Fix grading mask not showing up on core profile (Window)

### DIFF
--- a/include/xstudio/ui/opengl/opengl_shape_renderer.hpp
+++ b/include/xstudio/ui/opengl/opengl_shape_renderer.hpp
@@ -49,6 +49,11 @@ class OpenGLShapeRenderer {
         const std::vector<GLPolygon> &polygons,
         const std::vector<GLPoint> &points);
     std::array<GLuint, 4> ssbo_id_{0, 0, 0, 0};
+    // Core profile requires a bound VAO for any draw call, even when the
+    // vertex shader sources no attributes (it uses gl_VertexID). Without this
+    // the draw fails with GL_INVALID_OPERATION when no VAO happens to be bound
+    // - e.g. when rendering the grading mask into an offscreen FBO.
+    GLuint vao_{0};
 #endif
 
     std::unique_ptr<xstudio::ui::opengl::GLShaderProgram> shader_;

--- a/src/ui/opengl/src/opengl_shape_renderer.cpp
+++ b/src/ui/opengl/src/opengl_shape_renderer.cpp
@@ -869,12 +869,21 @@ void OpenGLShapeRenderer::init_gl() {
         shader_ = std::make_unique<ui::opengl::GLShaderProgram>(vertex_shader, frag_shader);
     }
 
+    if (vao_ == 0) {
+        glGenVertexArrays(1, &vao_);
+    }
+
     if (ssbo_id_ == std::array<GLuint, 4>{0, 0, 0, 0}) {
         glCreateBuffers(4, ssbo_id_.data());
     }
 }
 
 void OpenGLShapeRenderer::cleanup_gl() {
+
+    if (vao_ != 0) {
+        glDeleteVertexArrays(1, &vao_);
+        vao_ = 0;
+    }
 
     if (ssbo_id_ != std::array<GLuint, 4>{0, 0, 0, 0}) {
         glDeleteBuffers(4, ssbo_id_.data());
@@ -986,7 +995,9 @@ void OpenGLShapeRenderer::render_shapes(
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glBlendEquation(GL_FUNC_ADD);
 
+    glBindVertexArray(vao_);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    glBindVertexArray(0);
 
     // glEnable(GL_DEPTH_TEST);
     glDisable(GL_BLEND);


### PR DESCRIPTION
### Linked issues
N/A (couldn't find an existing issue for this)

### Summarize your change.
Bind a dedicated VAO around the draw call in the SSBO path of
`OpenGLShapeRenderer` so grading masks (polygon/ellipse/quad) actually
render on a core profile context.

### Describe the reason for the change.
Adding a polygon or ellipse mask to a grade layer did nothing on my
setup. The shape outline shows up, but the grade never applies inside it,
and the whole grade disappears the moment a mask is added.

The SSBO path in `OpenGLShapeRenderer` calls `glDrawArrays` without a VAO
bound. On a core profile context that's `GL_INVALID_OPERATION` and draws
nothing. It seemed fine before only because a VAO from the viewport was
still bound, but the grading mask renders into its own offscreen FBO
where no VAO is bound, so the mask texture ends up all zero and the grade
gets masked out completely.

Every other renderer here (stroke, caption, text, viewport) and the
`__OPENGL_4_1__` variant of this same class already bind their own VAO.
This path just missed it.

### Describe what you have tested and on which operating system.
Windows 11, NVIDIA RTX 3090, OpenGL 4.3 core profile context, built from
source.
- Before: adding an ellipse/polygon mask to a grade layer has no effect,
  the grade is invisible.
- After: the grade shows up correctly inside the mask, softness/opacity
  behave as expected.

I couldn't test on Linux, but Linux also runs a 4.3 core profile context,
so it already requires a bound VAO. Binding our own empty VAO doesn't
change behavior where it already worked (the vertex shader sources no
attributes, it only uses gl_VertexID), it just fixes the offscreen case,
so this should be safe there too.

### Add a list of changes, and note any that might need special attention during the review.
- `include/xstudio/ui/opengl/opengl_shape_renderer.hpp`: add a `vao_`
  member to the SSBO (`#else`) branch.
- `src/ui/opengl/src/opengl_shape_renderer.cpp`: create the VAO in
  `init_gl`, bind/unbind it around `glDrawArrays`, delete it in
  `cleanup_gl`.

Nothing tricky to review, it mirrors what the other renderers already do.

### If possible, provide screenshots.
before
<img width="1927" height="979" alt="image" src="https://github.com/user-attachments/assets/37abff8a-986b-4627-a42e-bfefd0811613" />

after
<img width="1392" height="913" alt="image" src="https://github.com/user-attachments/assets/ce34714a-42f2-4fbc-bcce-4cdc8e5e20ad" />
