### PR TITLE
Fix python actor event group callback routing

### DIFF
--- a/src/python_module/src/py_context.cpp
+++ b/src/python_module/src/py_context.cpp
@@ -23,8 +23,11 @@ class EventToPythonThreadLockerActor : public caf::event_based_actor {
         : caf::event_based_actor(cfg), context_(context) {
 
         behavior_.assign(
-            [=](xstudio::broadcast::broadcast_down_atom, const caf::actor_addr &) {
-                // TODO: self clean up
+            [=](xstudio::broadcast::broadcast_down_atom, const caf::actor_addr &actor) {
+                auto p = actor_to_callback_uuid_.find(actor);
+                if (p != actor_to_callback_uuid_.end()) {
+                    actor_to_callback_uuid_.erase(p);
+                }
             },
             [=](const xstudio::utility::Uuid &callback_id) {
                 // stop watching
@@ -59,8 +62,25 @@ class EventToPythonThreadLockerActor : public caf::event_based_actor {
                 }
             },
             [=](caf::actor events_source, const xstudio::utility::Uuid &callback_id) {
+
                 actor_to_callback_uuid_[caf::actor_cast<caf::actor_addr>(events_source)]
                     .push_back(callback_id);
+
+                // generally events emitted by an event_group appear to come from the PARENT
+                // of the event_group. This isn't 100% reliable, though, if an anon_send is
+                // used for the event message it appears to come from the event_group itself.
+                // So we will register the callback with the parent of the event_group, if 
+                // we can find it as well as the event_group itself.
+                mail(xstudio::utility::parent_atom_v).request(events_source, infinite).then(
+                    [=](caf::actor_addr parent) {
+                        if (parent) {
+                           actor_to_callback_uuid_[caf::actor_cast<caf::actor_addr>(parent)].push_back(callback_id);
+                        }
+                    },
+                    [=](const caf::error &) {
+                        // ignore the error - 'events_source' may not have a parent.
+                    });
+
                 // join the events broadcast
                 mail(
                     xstudio::broadcast::join_broadcast_atom_v,

--- a/src/utility/src/broadcast_actor.cpp
+++ b/src/utility/src/broadcast_actor.cpp
@@ -98,6 +98,7 @@ void BroadcastActor::init() {
     behavior_.assign(
         [=](xstudio::broadcast::broadcast_down_atom, const caf::actor_addr &) {},
         [=](bool) -> int { return int(subscribers_.size()); },
+        [=](utility::parent_atom) -> caf::actor_addr { return owner_; },
         [=](leave_broadcast_atom) -> bool {
             auto subscriber = caf::actor_cast<caf::actor_addr>(current_sender());
             if (subscriber && subscribers_.count(subscriber)) {


### PR DESCRIPTION
A small fix to correct a longstanding problem where setting up an event callback to watch event messages on a certain actor in Python does not work correctly.

In py_context.cpp a watcher actor subscribes to the desires event group and receives messages. It uses the address of the event group to register an ID for the python callback method to run when an event message is incoming from the event group. The problem was that the event messages appear to originate from the PARENT of the event_group through which events are broadcast, so when it tries to match up the sender of the message with the event_group actor address to work out which python methods to execute it can't do it.

Now when we set-up the routing we get the parent actor address of the event_group and use this to identify which python callbacks should be executed.