### PR TITLE
Auto playlist from bin selection.

### DIFF
--- a/include/xstudio/timeline/transient_selection_timeline.hpp
+++ b/include/xstudio/timeline/transient_selection_timeline.hpp
@@ -9,7 +9,7 @@ namespace xstudio::timeline {
 
 class TransientSelectionTimeline {
   public:
-    TransientSelectionTimeline() = default;
+    TransientSelectionTimeline()  = default;
     ~TransientSelectionTimeline() = default;
 
     // Synthesizes a new Timeline object based on the source playlist and current
@@ -20,8 +20,7 @@ class TransientSelectionTimeline {
     // alone: synthesizing the entire playlist here meant that merely clearing the
     // selection force-bound the viewport to a sequence of every item in the bin.
     [[nodiscard]] static Timeline synthesize(
-        const utility::UuidListContainer &playlist_media,
-        const utility::UuidSet &selection) {
+        const utility::UuidListContainer &playlist_media, const utility::UuidSet &selection) {
 
         Timeline t("Transient Selection");
         for (const auto &m : playlist_media.uuids()) {

--- a/include/xstudio/timeline/transient_selection_timeline.hpp
+++ b/include/xstudio/timeline/transient_selection_timeline.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <vector>
+#include "xstudio/timeline/timeline.hpp"
+#include "xstudio/utility/uuid.hpp"
+
+namespace xstudio::timeline {
+
+class TransientSelectionTimeline {
+  public:
+    TransientSelectionTimeline() = default;
+    ~TransientSelectionTimeline() = default;
+
+    // Synthesizes a new Timeline object based on the source playlist and current
+    // selection, preserving playlist order.
+    //
+    // An empty selection yields an EMPTY timeline, not the whole playlist. The
+    // caller is expected to treat that as "nothing to show" and leave the viewport
+    // alone: synthesizing the entire playlist here meant that merely clearing the
+    // selection force-bound the viewport to a sequence of every item in the bin.
+    [[nodiscard]] static Timeline synthesize(
+        const utility::UuidListContainer &playlist_media,
+        const utility::UuidSet &selection) {
+
+        Timeline t("Transient Selection");
+        for (const auto &m : playlist_media.uuids()) {
+            if (selection.count(m)) {
+                t.insert_media(m);
+            }
+        }
+        return t;
+    }
+};
+
+} // namespace xstudio::timeline

--- a/include/xstudio/ui/qml/session_model_ui.hpp
+++ b/include/xstudio/ui/qml/session_model_ui.hpp
@@ -16,6 +16,7 @@ CAF_PUSH_WARNINGS
 #include <QThreadPool>
 #include <QFutureWatcher>
 #include <QtConcurrent>
+#include <QTimer>
 CAF_POP_WARNINGS
 
 // namespace xstudio::timeline {
@@ -506,6 +507,13 @@ class SESSION_QML_EXPORT SessionModel : public caf::mixin::actor_object<JSONTree
 
   public slots:
     void updateMedia();
+    void debouncedSelectionChanged();
+
+  public:
+    // Takes ownership of a freshly built transient sequence and tears down the
+    // one it replaces. Must run on the GUI thread (it touches model members);
+    // debouncedSelectionChanged marshals it back with a queued invocation.
+    void adoptTransientSequence(const std::vector<caf::actor> &actors);
 
   signals:
 
@@ -665,6 +673,27 @@ class SESSION_QML_EXPORT SessionModel : public caf::mixin::actor_object<JSONTree
     QPersistentModelIndex mediaStatusIndex_;
     QPersistentModelIndex current_playlist_index_;
     QPersistentModelIndex current_playhead_owner_index_;
+
+    QTimer *selection_debounce_timer_{nullptr};
+
+    // Captured when the debounce is armed, so the synthesis works from a
+    // consistent snapshot of WHICH playlist changed. The selection itself is
+    // deliberately not cached: the vector handed to updateSelection is only a
+    // delta for SM_SELECT/SM_DESELECT/SM_TOGGLE, so it is re-queried from
+    // pending_selection_actor_ when the timer fires.
+    caf::actor pending_selection_actor_;
+    caf::actor pending_playlist_actor_;
+
+    // Every actor spawned for the transient sequence currently bound to the
+    // viewport. The timeline does not link its stack/tracks/clips (TrackActor
+    // only monitors them, see TrackActor::add_item), so exiting the timeline
+    // alone would not reclaim them - they are tracked and exited explicitly
+    // when the next sequence replaces this one.
+    std::vector<caf::actor> transient_sequence_actors_;
+
+    // Bounds the retry in updateViewportCurrentMediaContainerIndexFromBackend so
+    // a container that never appears in the model cannot re-arm it forever.
+    int viewport_container_retries_{0};
 
     QMap<QString, QImage> media_thumbnails_; // key is actor string
     utility::UuidSet processed_events_;

--- a/src/ui/qml/session/src/session_model_core_ui.cpp
+++ b/src/ui/qml/session/src/session_model_core_ui.cpp
@@ -77,7 +77,11 @@ SessionModel::SessionModel(QObject *parent) : super(parent) {
     selection_debounce_timer_ = new QTimer(this);
     selection_debounce_timer_->setSingleShot(true);
     selection_debounce_timer_->setInterval(150);
-    connect(selection_debounce_timer_, &QTimer::timeout, this, &SessionModel::debouncedSelectionChanged);
+    connect(
+        selection_debounce_timer_,
+        &QTimer::timeout,
+        this,
+        &SessionModel::debouncedSelectionChanged);
 }
 
 void SessionModel::fetchMore(const QModelIndex &parent) {

--- a/src/ui/qml/session/src/session_model_core_ui.cpp
+++ b/src/ui/qml/session/src/session_model_core_ui.cpp
@@ -73,6 +73,11 @@ SessionModel::SessionModel(QObject *parent) : super(parent) {
     setRoleNames(role_names);
     request_handler_ = new QThreadPool(this);
     request_handler_->setMaxThreadCount(8);
+
+    selection_debounce_timer_ = new QTimer(this);
+    selection_debounce_timer_->setSingleShot(true);
+    selection_debounce_timer_->setInterval(150);
+    connect(selection_debounce_timer_, &QTimer::timeout, this, &SessionModel::debouncedSelectionChanged);
 }
 
 void SessionModel::fetchMore(const QModelIndex &parent) {

--- a/src/ui/qml/session/src/session_model_methods_ui.cpp
+++ b/src/ui/qml/session/src/session_model_methods_ui.cpp
@@ -261,9 +261,26 @@ void SessionModel::updateViewportCurrentMediaContainerIndexFromBackend() {
 
         if (!r.isValid() && playlist) {
             // we didn't find the actor in the model ... this could be that the model is
-            // still building so re-try in 250ms
-            QTimer::singleShot(
-                250, this, SLOT(updateViewportCurrentMediaContainerIndexFromBackend()));
+            // still building so re-try in 250ms.
+            //
+            // Bounded, because not every container the viewport can be bound to has a
+            // node in the session model - a transient bin sequence does not. Re-arming
+            // unconditionally spun forever, each tick doing a blocking backend call and
+            // a recursive model walk on the GUI thread.
+            static constexpr int max_retries = 20; // ~5 seconds
+            if (viewport_container_retries_ < max_retries) {
+                viewport_container_retries_++;
+                QTimer::singleShot(
+                    250, this, SLOT(updateViewportCurrentMediaContainerIndexFromBackend()));
+            } else {
+                spdlog::debug(
+                    "{} gave up locating viewport media container in the session model "
+                    "after {} retries",
+                    __PRETTY_FUNCTION__,
+                    max_retries);
+            }
+        } else {
+            viewport_container_retries_ = 0;
         }
 
         if (r != current_playhead_owner_index_) {

--- a/src/ui/qml/session/src/session_model_ui.cpp
+++ b/src/ui/qml/session/src/session_model_ui.cpp
@@ -3,6 +3,9 @@
 #include "xstudio/media/media.hpp"
 #include "xstudio/session/session_actor.hpp"
 #include "xstudio/timeline/item.hpp"
+#include "xstudio/timeline/timeline_actor.hpp"
+#include "xstudio/timeline/clip_actor.hpp"
+#include "xstudio/timeline/transient_selection_timeline.hpp"
 #include "xstudio/ui/qml/caf_response_ui.hpp"
 #include "xstudio/ui/qml/job_control_ui.hpp"
 #include "xstudio/ui/qml/session_model_ui.hpp"
@@ -1295,16 +1298,205 @@ void SessionModel::updateSelection(
                     }
 
                     anon_mail(playlist::select_media_atom_v, uv, mode).send(actor);
+
+                    // Trigger the debounce for bin-driven sequence synthesis.
+                    // SM_NO_UPDATE is discarded by the backend so it cannot change
+                    // the selection, and must not cause a resynthesis.
+                    if (mode != playhead::SelectionMode::SM_NO_UPDATE and
+                        selection_debounce_timer_) {
+
+                        // Capture which playlist this belongs to, not the selection
+                        // itself - 'uv' is only a delta for SM_SELECT/SM_DESELECT/
+                        // SM_TOGGLE, so deselecting one item would otherwise
+                        // synthesize a sequence containing just that item.
+                        pending_selection_actor_ = actor;
+                        pending_playlist_actor_ =
+                            current_playlist_index_.isValid()
+                                ? actorFromQString(
+                                      system(),
+                                      current_playlist_index_.data(actorRole).toString())
+                                : caf::actor();
+
+                        selection_debounce_timer_->start();
+                    }
                 }
             }
         }
     } catch (const std::exception &err) {
         spdlog::warn("{} {}", __PRETTY_FUNCTION__, err.what());
-        /*if (index.isValid()) {
-            nlohmann::json &j = indexToData(index);
-            spdlog::warn("{}", j.dump(2));
-        }*/
     }
+}
+
+namespace {
+// Tear down a set of actors we spawned. Nothing links them to us, so they have
+// to be exited explicitly or they outlive the sequence they belong to.
+void exit_actors(caf::actor_system &sys_ref, const std::vector<caf::actor> &actors) {
+    if (actors.empty())
+        return;
+    scoped_actor sys{sys_ref};
+    for (const auto &a : actors) {
+        if (a)
+            sys->send_exit(a, caf::exit_reason::user_shutdown);
+    }
+}
+
+// How long any single backend round-trip in the synthesis may take. The old code
+// used caf::infinite on the GUI thread; this work is now on a pool thread, but an
+// unbounded wait there still parks a worker permanently if an actor wedges.
+constexpr auto k_synthesis_timeout = std::chrono::seconds(5);
+} // namespace
+
+void SessionModel::adoptTransientSequence(const std::vector<caf::actor> &actors) {
+    auto previous = transient_sequence_actors_;
+    transient_sequence_actors_ = actors;
+    exit_actors(system(), previous);
+}
+
+void SessionModel::debouncedSelectionChanged() {
+    // Read everything that must come off the GUI thread here, then do the CAF work
+    // on the request handler pool: this slot used to make unbounded blocking calls
+    // (plus one blocking ClipActor construction per selected item) on the GUI
+    // thread, which froze the UI for large selections.
+    const auto selection_actor = pending_selection_actor_;
+    const auto playlist_actor  = pending_playlist_actor_;
+
+    if (not selection_actor or not playlist_actor)
+        return;
+
+    if (current_playlist_index_.isValid()) {
+        const auto type = StdFromQString(current_playlist_index_.data(typeRole).toString());
+        if (type != "Playlist" and type != "Subset")
+            return;
+    }
+
+    QtConcurrent::run(request_handler_, [this, selection_actor, playlist_actor]() {
+        std::vector<caf::actor> spawned;
+
+        try {
+            scoped_actor sys{system()};
+
+            // Ask for the authoritative selection rather than replaying the delta
+            // that was captured when the debounce was armed - by now the backend
+            // has applied it, and the user may have added to it several times.
+            auto selected = request_receive_wait<utility::UuidList>(
+                *sys,
+                selection_actor,
+                k_synthesis_timeout,
+                playhead::get_selection_atom_v);
+
+            if (selected.empty()) {
+                // Nothing selected: leave the viewport showing whatever it has.
+                return;
+            }
+
+            auto all_media = request_receive_wait<utility::UuidActorVector>(
+                *sys, playlist_actor, k_synthesis_timeout, playlist::get_media_atom_v);
+
+            utility::UuidListContainer playlist_media;
+            std::map<utility::Uuid, utility::UuidActor> media_by_uuid;
+            for (const auto &m : all_media) {
+                playlist_media.insert(m.uuid());
+                media_by_uuid[m.uuid()] = m;
+            }
+
+            const utility::UuidSet selection(selected.begin(), selected.end());
+            auto transient_timeline =
+                timeline::TransientSelectionTimeline::synthesize(playlist_media, selection);
+
+            if (transient_timeline.media().empty()) {
+                // The selection belongs to a different playlist than the one we
+                // read media from, or every selected item has since been removed.
+                return;
+            }
+
+            auto tactor = system().spawn<timeline::TimelineActor>(
+                "Transient Sequence",
+                utility::FrameRate(timebase::k_flicks_24fps),
+                transient_timeline.uuid(),
+                playlist_actor,
+                true // with_tracks
+            );
+            spawned.push_back(tactor);
+
+            auto new_item = request_receive_wait<timeline::Item>(
+                *sys, tactor, k_synthesis_timeout, timeline::item_atom_v);
+
+            // The root item's first child is the Stack, whose first child is the
+            // Video Track.
+            auto stack_opt = new_item.item_at_index(0);
+            if (not stack_opt)
+                throw std::runtime_error("transient sequence has no stack");
+            if (auto stack_actor = caf::actor_cast<caf::actor>((*stack_opt)->actor_addr()))
+                spawned.push_back(stack_actor);
+
+            auto track_opt = (*stack_opt)->item_at_index(0);
+            if (not track_opt)
+                throw std::runtime_error("transient sequence has no video track");
+            auto track_actor = caf::actor_cast<caf::actor>((*track_opt)->actor_addr());
+            if (not track_actor)
+                throw std::runtime_error("transient sequence video track is invalid");
+            spawned.push_back(track_actor);
+
+            for (const auto &muuid : transient_timeline.media()) {
+                auto mit = media_by_uuid.find(muuid);
+                if (mit == std::end(media_by_uuid))
+                    continue;
+
+                // Register the media in the timeline's pool BEFORE inserting the
+                // clip that refers to it. These are different actors, so the two
+                // messages have no ordering guarantee between them and have to be
+                // sequenced explicitly.
+                std::ignore = request_receive_wait<utility::UuidActor>(
+                    *sys,
+                    tactor,
+                    k_synthesis_timeout,
+                    playlist::add_media_atom_v,
+                    mit->second,
+                    utility::Uuid());
+
+                auto clip_uuid  = utility::Uuid::generate();
+                auto clip_actor = system().spawn<timeline::ClipActor>(
+                    mit->second, "Clip", clip_uuid);
+                spawned.push_back(clip_actor);
+
+                std::ignore = request_receive_wait<utility::JsonStore>(
+                    *sys,
+                    track_actor,
+                    k_synthesis_timeout,
+                    timeline::insert_item_atom_v,
+                    -1,
+                    utility::UuidActorVector({utility::UuidActor(clip_uuid, clip_actor)}));
+            }
+
+            // Bind the viewport only once the sequence is fully populated,
+            // otherwise the session can build a playhead over an empty timeline.
+            anon_mail(
+                session::viewport_active_media_container_atom_v,
+                utility::UuidActor(transient_timeline.uuid(), tactor))
+                .send(session_actor_);
+
+            // Hand ownership to the GUI thread, which retires the previous
+            // sequence. Cleared first so the error path below cannot also exit it.
+            auto adopted = spawned;
+            spawned.clear();
+            QMetaObject::invokeMethod(
+                this,
+                [this, adopted]() { adoptTransientSequence(adopted); },
+                Qt::QueuedConnection);
+
+            spdlog::debug(
+                "SessionModel::debouncedSelectionChanged - bound transient sequence of {} "
+                "clips to viewport.",
+                transient_timeline.media().size());
+
+        } catch (const std::exception &err) {
+            spdlog::warn("SessionModel::debouncedSelectionChanged failed: {}", err.what());
+        }
+
+        // Anything spawned but not adopted (any failure above) must not be left
+        // running - it is unreachable and holds MediaActor references.
+        exit_actors(system(), spawned);
+    });
 }
 
 void SessionModel::updateMediaListFilterString(

--- a/src/ui/qml/session/src/session_model_ui.cpp
+++ b/src/ui/qml/session/src/session_model_ui.cpp
@@ -1347,7 +1347,7 @@ constexpr auto k_synthesis_timeout = std::chrono::seconds(5);
 } // namespace
 
 void SessionModel::adoptTransientSequence(const std::vector<caf::actor> &actors) {
-    auto previous = transient_sequence_actors_;
+    auto previous              = transient_sequence_actors_;
     transient_sequence_actors_ = actors;
     exit_actors(system(), previous);
 }
@@ -1379,10 +1379,7 @@ void SessionModel::debouncedSelectionChanged() {
             // that was captured when the debounce was armed - by now the backend
             // has applied it, and the user may have added to it several times.
             auto selected = request_receive_wait<utility::UuidList>(
-                *sys,
-                selection_actor,
-                k_synthesis_timeout,
-                playhead::get_selection_atom_v);
+                *sys, selection_actor, k_synthesis_timeout, playhead::get_selection_atom_v);
 
             if (selected.empty()) {
                 // Nothing selected: leave the viewport showing whatever it has.
@@ -1454,9 +1451,9 @@ void SessionModel::debouncedSelectionChanged() {
                     mit->second,
                     utility::Uuid());
 
-                auto clip_uuid  = utility::Uuid::generate();
-                auto clip_actor = system().spawn<timeline::ClipActor>(
-                    mit->second, "Clip", clip_uuid);
+                auto clip_uuid = utility::Uuid::generate();
+                auto clip_actor =
+                    system().spawn<timeline::ClipActor>(mit->second, "Clip", clip_uuid);
                 spawned.push_back(clip_actor);
 
                 std::ignore = request_receive_wait<utility::JsonStore>(


### PR DESCRIPTION
### Auto playlist from bin selection.

When you select multiple elements in a bin, the viewer stops showing anything. This change means that a temporary playlist is generated from the selection in the viewer, so you dont have to make an explicit Sequence to view the clips in sequence.

### Describe the reason for the change.
The timeline viewer is almost too much if all you want to do is view and re-order a playlist, without trimming. This puts that control directly in the Playlist control, based on what the current selection is.

### Describe what you have tested and on which operating system.
I've only tested on MacOS, but have tested a variety of playlists.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.
<img width="1033" height="492" alt="Kapture 2026-08-11 at 12 06 04" src="https://github.com/user-attachments/assets/3e79f084-4ed0-4bc4-b694-8446c762305b" />

This was created with assistance from Gemini and Claude.