### PR TITLE
Ignore XQuartz prefixes in find_package() on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,12 @@ set(XSTUDIO_GLOBAL_NAME xStudio)
 
 project(${XSTUDIO_GLOBAL_NAME} VERSION ${XSTUDIO_GLOBAL_VERSION} LANGUAGES CXX)
 
+# XQuartz's Mesa libGL under /opt/X11 shadows OpenGL.framework, so keep it off the search path.
+if(APPLE)
+    list(APPEND CMAKE_IGNORE_PREFIX_PATH /opt/X11 /usr/X11 /usr/X11R6)
+    list(REMOVE_DUPLICATES CMAKE_IGNORE_PREFIX_PATH)
+endif()
+
 # Work around Qt bug: FindWrapOpenGL.cmake links -framework AGL, which was
 # removed from the macOS SDK in 10.14. Fixed upstream in Qt 6.9+ but not
 # backported to 6.5/6.8 LTS (see https://codereview.qt-project.org/c/qt/qtbase/+/652022).


### PR DESCRIPTION
Summarize your change.
On macOS, add /opt/X11, /usr/X11 and /usr/X11R6 to CMAKE_IGNORE_PREFIX_PATH so find_package() never resolves against an XQuartz installation.

Describe the reason for the change.
XQuartz installs a Mesa libGL/libGLU plus GL/gl.h under /opt/X11, which is also reachable as /usr/X11 and /usr/X11R6. All three are searched by CMake by default via CMAKE_SYSTEM_PREFIX_PATH.

Two things combine to make Mesa win over the system OpenGL:

CMake's FindOpenGL accepts those names on APPLE.
The vcpkg toolchain sets CMAKE_FIND_FRAMEWORK=LAST, which deprioritises OpenGL.framework.
The result is that on any machine with XQuartz installed, the build compiles against Mesa headers and links Mesa libraries instead of the system ones. The same prefixes also shadow freetype, png and other dependencies, so the prefixes are ignored wholesale rather than patching FindOpenGL alone.

XQuartz is common on developer machines (it is pulled in by a number of unrelated tools), so this fails for contributors who have never deliberately installed it.

Describe what you have tested and on which operating system.
Built on Mac Air M1, MacOS Sequoia 15.7.4, with latest XQuartz installed using brew 

Add a list of changes, and note any that might need special attention during the review.
CMakeLists.txt: new if(APPLE) block appending the three X11 prefixes to CMAKE_IGNORE_PREFIX_PATH, followed by list(REMOVE_DUPLICATES ...).

Notes for review:

The block is placed immediately after project() and before any find_package() call, which is required for it to take effect.
CMAKE_IGNORE_PREFIX_PATH requires CMake 3.23+.
macOS-only. Guarded by if(APPLE), so Linux and Windows builds are unaffected.