### PR TITLE
Remove GLEW dependency for MacOS

### DIFF
--- a/src/plugin/colour_pipeline/ocio/src/CMakeLists.txt
+++ b/src/plugin/colour_pipeline/ocio/src/CMakeLists.txt
@@ -1,7 +1,6 @@
 find_package(OpenColorIO)
 find_package(OpenEXR)
 find_package(Imath)
-find_package(GLEW REQUIRED)
 
 # Temporary hack - OCIO package is not found/defined by 'modern' .cmake
 # package and as such cmake doesn't distinguish the OCIO headers as system
@@ -12,7 +11,6 @@ include_directories(SYSTEM ${OCIO_INCLUDE_DIRS})
 SET(LINK_DEPS
 	xstudio::colour_pipeline
 	xstudio::module
-	GLEW::GLEW
 	OpenColorIO::OpenColorIO
 	OpenEXR::OpenEXR
 	Imath::Imath

--- a/src/plugin/media_reader/ffmpeg/src/CMakeLists.txt
+++ b/src/plugin/media_reader/ffmpeg/src/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(media_reader_ffmpeg VERSION ${XSTUDIO_GLOBAL_VERSION} LANGUAGES CXX)
 
-find_package(GLEW REQUIRED)
-
 set(SOURCES
 	ffmpeg_stream.cpp
 	ffmpeg_decoder.cpp
@@ -26,7 +24,6 @@ if (${USE_VCPKG})
 	target_link_libraries(${PROJECT_NAME}
 		PUBLIC
 			xstudio::media_reader
-			GLEW::GLEW
 		PRIVATE 
 			${FFMPEG_LIBRARIES}
 		)
@@ -40,7 +37,6 @@ else()
 	target_link_libraries(${PROJECT_NAME}
 		PUBLIC
 			xstudio::media_reader
-			GLEW::GLEW
 			FFMPEG::avcodec
 			FFMPEG::avformat
 			FFMPEG::swscale

--- a/src/ui/opengl/src/CMakeLists.txt
+++ b/src/ui/opengl/src/CMakeLists.txt
@@ -1,8 +1,6 @@
 SET(LINK_DEPS
 	CAF::core
     OpenGL::GL
-	OpenGL::GLU
-	GLEW::GLEW
     xstudio::ui::base
     xstudio::ui::canvas
     xstudio::ui::viewport
@@ -17,8 +15,13 @@ if(UNIX)
     list(APPEND LINK_DEPS pthread)
 endif()
 
+if (NOT APPLE)
+	find_package(GLEW REQUIRED)
+    list(APPEND LINK_DEPS GLEW::GLEW)
+endif()
+
+
 find_package(OpenGL REQUIRED)
-find_package(GLEW REQUIRED)
 find_package(OpenEXR)
 find_package(Imath)
 
@@ -38,6 +41,4 @@ endif()
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
 		freetype
-	PUBLIC
-		GLEW::GLEW
 )

--- a/src/ui/opengl/src/gl_debug_utils.cpp
+++ b/src/ui/opengl/src/gl_debug_utils.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-#ifdef __linux__
-#include <GL/gl.h>
+#ifdef __apple__
+#include <OpenGL/gl3.h>
 #else
 #include <GL/glew.h>
+#include <GL/gl.h>
 #endif
 #include <ImfRgbaFile.h>
 #include <vector>


### PR DESCRIPTION
### Remove glew dependencies for MacOS

The dependency on the GLEW library is causing problems when building on MacOS, particularly when multiple GLEW versions have been installed on the system (e.g. if XQuartz has been installed).

It turns out that GLEW is not required on MacOS - xSTUDIO does not require any OpenGL extensions that aren't already defined in the Frameworks.OpenGL headers (or perhaps GLEW has become somewhat unnecessary on MacOS).

The changes in this commit only affect the MacOS build path and remove GLEW being added as a dependency.