### PR TITLE
337: Filesystem browser thumbnail fallback: offscreen viewport has no render handler for supplied ImageBufPtr

### DIFF
--- a/src/ui/qt/viewport_widget/src/offscreen_viewport.cpp
+++ b/src/ui/qt/viewport_widget/src/offscreen_viewport.cpp
@@ -283,6 +283,39 @@ OffscreenViewport::OffscreenViewport(const std::string name, bool sync_with_main
                 },
 
                 [=](render_viewport_to_image_atom,
+                    const int width,
+                    const int height,
+                    const media_reader::ImageBufPtr image) -> result<thumbnail::ThumbnailBufferPtr> {
+                    try {
+                        // Render a supplied full-res image down to a thumbnail via the
+                        // viewport's colour-managed pipeline. The image buffer may be in
+                        // any reader-provided format; the offscreen render normalises it to
+                        // RGBA_16F, which rgb96thumbFromHalfFloatImage expects.
+                        if (!image || width <= 0 || height <= 0)
+                            return caf::make_error(
+                                xstudio_error::error,
+                                "OffscreenViewport render-to-thumbnail: invalid image or "
+                                "dimensions.");
+                        media_reader::ImageBufPtr rendered(new media_reader::ImageBuffer());
+                        renderToImageBuffer(
+                            width,
+                            height,
+                            rendered,
+                            ImageFormat::RGBA_16F,
+                            true,
+                            utility::clock::now(),
+                            image,
+                            false, // include_overlays
+                            true); // include_drawings
+                        thumbnail::ThumbnailBufferPtr r = rgb96thumbFromHalfFloatImage(rendered);
+                        r->convert_to(thumbnail::TF_RGB24);
+                        return r;
+                    } catch (std::exception &e) {
+                        return caf::make_error(xstudio_error::error, e.what());
+                    }
+                },
+
+                [=](render_viewport_to_image_atom,
                     caf::actor media_actor,
                     const int media_frame,
                     const thumbnail::THUMBNAIL_FORMAT format,


### PR DESCRIPTION
### Linked issues

Fixes #337 

### Summarize your change.

Add the missing `render_viewport_to_image_atom` message handler to `OffscreenViewport` that renders a supplied `media_reader::ImageBufPtr` down to a thumbnail:

```cpp
(render_viewport_to_image_atom, int width, int height, media_reader::ImageBufPtr)
    -> thumbnail::ThumbnailBufferPtr  // TF_RGB24
```

The handler renders the supplied full-resolution image through the viewport's colour-managed offscreen pipeline (`renderToImageBuffer` → `RGBA_16F`) and converts the result to an RGB24 `ThumbnailBufferPtr` via the existing `rgb96thumbFromHalfFloatImage`, mirroring the regular `renderToThumbnail` path. Invalid input (null buffer or non-positive dimensions) returns a CAF error instead of dereferencing or attempting an invalid FBO size.

File changed: `src/ui/qt/viewport_widget/src/offscreen_viewport.cpp` (+33 lines).

### Describe the reason for the change.

When a media reader cannot produce a thumbnail buffer directly (`MediaDetailAndThumbnailReaderActor::get_thumbnail_from_reader_plugin`, `src/media_reader/src/media_detail_and_thumbnail_reader_actor.cpp`), it falls back to reading the full image and asking the offscreen viewport to render it to a thumbnail, sending:

```cpp
mail(ui::viewport::render_viewport_to_image_atom_v, thumb_width, thumb_height, buf)  // buf = ImageBufPtr
```

`OffscreenViewport` had no handler for this signature, so the CAF runtime reported it as an unexpected message:

```console
unexpected message [id: 651, name: user.scheduled-actor]: message(xstudio::ui::viewport::render_viewport_to_image_atom(), 128, 72, xstudio::media_reader::ImageBufPtr)
```

The failed request propagated back as an error, which the QML thumbnail provider (`ThumbnailReader` in `src/ui/qml/helper/src/thumbnail_provider_ui.cpp`) reported as `"Thumbnail does not exist 2."` — surfaced at the filesystem browser delegate:

```console
qrc:/FileSystemBrowser/FileSystemBrowser/xstudio/FSThumbItem.qml:74:21: QML QQuickImage*: Thumbnail does not exist 2.
```

So formats that took the full-image fallback showed blank thumbnails and spammed these two messages whenever the filesystem browser loaded thumbnails.

### Describe what you have tested and on which operating system.

- Windows 10 (x64), MSVC 2022, Release.
- The reported messages are gone: loading thumbnails in the filesystem browser no longer produces the `unexpected message` CAF warning or the `Thumbnail does not exist 2.` QML error for media that exercises the full-image fallback.

### Add a list of changes, and note any that might need special attention during the review.

- `src/ui/qt/viewport_widget/src/offscreen_viewport.cpp`: new `(render_viewport_to_image_atom, int, int, media_reader::ImageBufPtr)` handler returning `ThumbnailBufferPtr` (RGB24), with null/dimension validation.
- Note for review: the new handler is intentionally signature-distinct from the existing `(atom, int, int, ImageFormat) → ImageBufPtr` handler — its third element is the image buffer, not a pixel format — so CAF dispatch is unambiguous. It reuses the existing `renderToImageBuffer` / `rgb96thumbFromHalfFloatImage` colour-management path; no other code was touched.

### If possible, provide screenshots.

N/A — the observable change is the absence of the two console/QML error messages above.
