### PR TITLE
feat(filesystem_browser) Misc fixes and improvements

### DIFF
--- a/include/xstudio/ui/qml/helper_ui.hpp
+++ b/include/xstudio/ui/qml/helper_ui.hpp
@@ -678,8 +678,10 @@ class HELPER_QML_EXPORT Helpers : public QObject {
         return result;
     }
 
-    Q_INVOKABLE [[nodiscard]] QUrl QUrlFromPosixPath(const QString &path) const {
-        return QUrlFromUri(utility::posix_path_to_uri(path.toStdString()));
+    Q_INVOKABLE [[nodiscard]] QUrl QUrlFromPosixPath(const QString &path,
+                                                     const bool abspath = false,
+                                                     const bool remap = true) const {
+        return QUrlFromUri(utility::posix_path_to_uri(path.toStdString(), abspath, remap));
     }
 
     Q_INVOKABLE [[nodiscard]] QString fileFromURL(const QUrl &url) const {

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSDirectoryTreeBody.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSDirectoryTreeBody.qml
@@ -15,7 +15,14 @@ Item {
     // Properties to communicate with parent
     property var currentPath: "/"
     property string baseRootPath: "/"
-    
+
+    Connections {
+        target: root
+        function onTreeBaseRootPathChanged() {
+            baseRootPath = stripTrailingPathSeparator(treeBaseRootPath)
+        }
+    }
+
     signal sendCommand(var cmd)
     //onSendCommand: (cmd) => console.log("DirectoryTree: Sending command: " + JSON.stringify(cmd))
     
@@ -57,6 +64,9 @@ Item {
             pendingExpandPath = currentPath;
             isSyncing = true;
             syncToPath();
+
+            if (!currentPath.startsWith(baseRootPath))
+                baseRootPath = "/"
         }
     }
 
@@ -230,9 +240,11 @@ Item {
         }
         
         treeModel.setProperty(index, "isLoading", true);
-        
-        // Request subdirs
-        sendCommand({"action": "get_subdirs", "path": node.path});
+
+        // Request subdirs, but after a delay to allow any "change_path" command to complete
+        callbackTimer.setTimeout(function() { return function() {
+            sendCommand({"action": "get_subdirs", "path": node.path})
+        }}(), 200);
     }
     
     function collapseNode(index) {
@@ -355,7 +367,7 @@ Item {
             menuItemPosition: 2
             menuPath: ""
             onActivated: {
-                helpers.showURIS([helpers.QUrlFromPosixPath(treeContextMenu.path)])
+                helpers.showURIS([helpers.QUrlFromPosixPath(treeContextMenu.path, false, false)])
             }
             menuModelName: treeContextMenu.menu_model_name
         }

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSFileContextMenu.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSFileContextMenu.qml
@@ -57,11 +57,15 @@ XsPopupMenu {
         menuPath: ""
         menuItemPosition: 5
         onActivated: {
-            if (itemPath) {
-                helpers.showURIS([helpers.QUrlFromPosixPath(itemPath)])
-            } else if (selectedItemsPaths.length > 0) {
-                helpers.showURIS([helpers.QUrlFromPosixPath(selectedItemsPaths[0])])
+            let path = itemPath ? itemPath : selectedItemsPaths[0]
+            // extract first frame if it is a sequence
+            const match = path.match(/(\{:([0-9]+)d\})\.[^=]+(=(\d+)[,-][0-9,-]+)$/)
+            if (match) {
+                let pad = parseInt(match[2], 10)
+                path = path.replace(match[1], match[4].padStart(pad, "0"))
+                path = path.replace(match[3], "")
             }
+            helpers.showURIS([helpers.QUrlFromPosixPath(path, false, false)])
         }
         menuModelName: fileContextMenu.menu_model_name
     }

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSPathInput.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSPathInput.qml
@@ -361,6 +361,8 @@ RowLayout {
                             hoverEnabled: true
                             onClicked: {
                                 sendCommand({"action": "change_path", "path": modelData.path})
+                                if (modelData.isPinned)
+                                    treeBaseRootPath = modelData.path
                                 pathPopup.close()
                             }
                         }

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSThumbGroup.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FSThumbGroup.qml
@@ -38,9 +38,11 @@ Item {
         XsText {
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: folderIcon.right; anchors.leftMargin: 10
+            anchors.right: parent.right; anchors.rightMargin: 10
             text: path + "   (" + total_file_count + ")"
             font.bold: true
             elide: Text.ElideLeft
+            horizontalAlignment: Text.AlignLeft
             font.pixelSize: 14
         }
     }

--- a/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
+++ b/src/plugin/utility/filesystem_browser/FileSystemBrowser/xstudio/FileSystemBrowser.qml
@@ -34,6 +34,8 @@ Item {
     // uri requires triple slash before drive letter on Windows, since this is the root.
     property var thumbSrcRoot: Qt.platform.os === "windows" ? "image://thumbnail/file:///" : "image://thumbnail/file://"
 
+    property string treeBaseRootPath: "/"
+
     onVisibleChanged: {
         if (!visible)
             sendCommand({"action": "stop_scan"})
@@ -179,13 +181,15 @@ Item {
                     let idx = scanResultsModel.index(j, 0, selectedItems[i])
                     if (scanResultsModel.get(idx, "is_folder")) continue;
                     else {
-                        v.push(helpers.QUrlFromPosixPath(scanResultsModel.get(idx, "path")))
-                        v2.push(scanResultsModel.get(idx, "path"))
+                        let path = scanResultsModel.get(idx, "path")
+                        v.push(helpers.QUrlFromPosixPath(path))
+                        v2.push(path)
                     }
                 }
             } else {
-                v.push(helpers.QUrlFromPosixPath(scanResultsModel.get(selectedItems[i], "path")))
-                v2.push(scanResultsModel.get(selectedItems[i], "path"))
+                let path = scanResultsModel.get(selectedItems[i], "path")
+                v.push(helpers.QUrlFromPosixPath(path))
+                v2.push(path)
             }
         }
         selectedItemsUrls = v
@@ -683,7 +687,7 @@ Item {
                                 
                     onReleased: (mouse)=> {
 
-                        if (underMouseIndex != -1 && mouse.button === Qt.LeftButton && mouse.modifiers == Qt.NoModifier) {    
+                        if (underMouseIndex != undefined && mouse.button === Qt.LeftButton && mouse.modifiers == Qt.NoModifier) {    
                             selectedItems = []
                             selectItem(underMouseIndex, 0)
                             
@@ -700,7 +704,7 @@ Item {
                     }
 
                     onDoubleClicked: (mouse) => {
-                        if (mouse.button === Qt.LeftButton && underMouseIndex != -1) {
+                        if (mouse.button === Qt.LeftButton && underMouseIndex != undefined) {
 
                             if (scanResultsModel.get(underMouseIndex, "is_folder")) {
                                 sendCommand({"action": "change_path", "path": scanResultsModel.get(underMouseIndex, "path")});
@@ -712,7 +716,7 @@ Item {
 
                     onClicked: (mouse) => {
 
-                        if (mouse.button === Qt.RightButton && underMouseIndex != -1) {
+                        if (mouse.button === Qt.RightButton && underMouseIndex != undefined) {
                             if (!selectedItems.includes(underMouseIndex)) {
                                 selectedItems = [underMouseIndex]
                             }
@@ -735,7 +739,7 @@ Item {
                         target: null
 
                         onActiveChanged: {
-                            if (active && underMouseIndex != -1) {
+                            if (active && underMouseIndex != undefined) {
                                 dragProxy.grabToImage(function(result) {
                                     let d = root.selectedItemsPaths.map(p => encodeURIComponent(p))
                                     dragProxy.Drag.mimeData = {"text/plain": d.join("\n")}


### PR DESCRIPTION
Add support for path remapping when doing "Reveal in Finder".

Fix issue preventing "Reveal on Disk" from working with image sequences.

Jumping to a pinned location also sets it as the root path for better browsing of frequently visited locations containing many subdirectories..

Plus a small UI layout fix.
